### PR TITLE
feat: add an autosave feature 

### DIFF
--- a/frontend/app/components/MarkdownEditor/LazyMarkdownEditor.vue
+++ b/frontend/app/components/MarkdownEditor/LazyMarkdownEditor.vue
@@ -44,7 +44,7 @@ const resourcesStore = useRessourcesStore();
 const preferencesStore = usePreferences();
 
 const props = defineProps<{ doc?: Partial<Document>; minimal?: boolean }>();
-const emit = defineEmits(['save', 'exit']);
+const emit = defineEmits(['save', 'exit', 'autoSave']);
 
 const editorContainer = ref<HTMLDivElement>();
 const markdownPreview = ref<HTMLDivElement>();
@@ -389,7 +389,7 @@ const autoSave = debounceDelayed(() => {
   const content = editorView.value?.state.doc.toString() || '';
   document.value.content_markdown = content;
   document.value.content_html = compile(content);
-  emit('save', document.value);
+  emit('autoSave', document.value);
 }, 2000)
 </script>
 

--- a/frontend/app/components/MarkdownEditor/LazyMarkdownEditor.vue
+++ b/frontend/app/components/MarkdownEditor/LazyMarkdownEditor.vue
@@ -378,17 +378,19 @@ function syncScroll() {
   markdownPreview.value.scrollTop = scrollPercentage * (markdownPreview.value.scrollHeight - markdownPreview.value.clientHeight);
 }
 
-const save = debounce(() => {
+function updateDocumentContent() {
   const content = editorView.value?.state.doc.toString() || '';
   document.value.content_markdown = content;
   document.value.content_html = compile(content);
+}
+
+const save = debounce(() => {
+  updateDocumentContent();
   emit('save', document.value);
 }, 1000);
 
 const autoSave = debounceDelayed(() => {
-  const content = editorView.value?.state.doc.toString() || '';
-  document.value.content_markdown = content;
-  document.value.content_html = compile(content);
+  updateDocumentContent();
   emit('autoSave', document.value);
 }, 2000)
 </script>

--- a/frontend/app/composables/Preferences.ts
+++ b/frontend/app/composables/Preferences.ts
@@ -10,6 +10,7 @@ export const DEFAULT_PREFERENCES = {
   primaryColor: -2 as number, // -2 default primary; -1 unset; >= 0 app color index
   docSize: 1 as number, // 0 = small, 1 = large
   theme: 'alexandrie' as string,
+  documentAutoSave: true as boolean, // Enable automatic saving of documents
   sidebarItems: {
     manageCategories: true as boolean,
     cdn: true as boolean,

--- a/frontend/app/composables/utils.ts
+++ b/frontend/app/composables/utils.ts
@@ -62,3 +62,28 @@ export function debounce<T extends (...args: unknown[]) => void>(fn: T, delay = 
     }
   };
 }
+
+/**
+ * Creates a debounced version of the provided function that delays its execution until after
+ * a specified wait time has elapsed since the last time it was invoked. Unlike the standard
+ * debounce, this version only executes the function after the delay period, and resets the timer
+ * on each call (no immediate execution).
+ *
+ * @param fn - The function to debounce.
+ * @param delay - The number of milliseconds to delay invocation (default: 2000).
+ * @returns A debounced function that delays invoking `fn` until after `delay` ms have elapsed since the last call.
+ */
+export function debounceDelayed<T extends (...args: unknown[]) => void>(fn: T, delay = 2000) {
+  let timeout: ReturnType<typeof setTimeout> | null = null;
+
+  return (...args: Parameters<T>) => {
+    // Annuler le timer précédent
+    if (timeout) clearTimeout(timeout);
+    
+    // Lancer un nouveau timer
+    timeout = setTimeout(() => {
+      fn(...args);
+      timeout = null;
+    }, delay);
+  };
+}

--- a/frontend/app/composables/utils.ts
+++ b/frontend/app/composables/utils.ts
@@ -77,10 +77,10 @@ export function debounceDelayed<T extends (...args: unknown[]) => void>(fn: T, d
   let timeout: ReturnType<typeof setTimeout> | null = null;
 
   return (...args: Parameters<T>) => {
-    // Annuler le timer précédent
+    // Cancel the previous timer
     if (timeout) clearTimeout(timeout);
     
-    // Lancer un nouveau timer
+    // Launch a new timer
     timeout = setTimeout(() => {
       fn(...args);
       timeout = null;

--- a/frontend/app/pages/dashboard/docs/edit/[id].vue
+++ b/frontend/app/pages/dashboard/docs/edit/[id].vue
@@ -1,5 +1,5 @@
 <template>
-  <MarkdownEditor v-if="document" ref="editor" :doc="document" @save="data => save(data)" @exit="exit" />
+  <MarkdownEditor v-if="document" ref="editor" :doc="document" @save="data => save(data)" @autoSave="data => autoSave(data)" @exit="exit" />
 </template>
 <script lang="ts" setup>
 import type { Document } from '~/stores';
@@ -32,6 +32,11 @@ function save(doc: Document) {
     .then(() => notifications.add({ type: 'success', title: 'Document successfully updated' }))
     .catch(e => notifications.add({ type: 'error', title: 'Error', message: e }));
 }
+
+function autoSave(doc: Document) {
+  store.update(doc)
+}
+
 function exit() {
   useRouter().push(`/dashboard/docs/${doc_id}`);
 }

--- a/frontend/app/pages/dashboard/settings/_views/preferences.vue
+++ b/frontend/app/pages/dashboard/settings/_views/preferences.vue
@@ -103,6 +103,7 @@ const options = ref<{ label: string; options: Option[] }[]>([
     options: [
       { label: 'Enable Print Mode', type: 'toggle', key: 'printMode', value: Boolean(preferencesStore.get('printMode')) },
       { label: 'Hide Table of Content', type: 'toggle', key: 'hideTOC', value: Boolean(preferencesStore.get('hideTOC')) },
+      { label: 'Enable Document Auto-save', type: 'toggle', key: 'documentAutoSave', value: Boolean(preferencesStore.get('documentAutoSave')) },
       {
         label: 'Document size',
         type: 'radio',


### PR DESCRIPTION
## Summary
This feature introduces an **autosave option** that can be toggled in the user preferences.  

## Details
- A new preference setting has been added to enable or disable autosave.  
- **Default value**: `true`.  
- When enabled, autosave is triggered **2 seconds after the user's last modification**.  

## Why
This improves the user experience by ensuring progress is not lost, while still allowing users to disable autosave if they prefer manual saving.

## Notes
- Default behavior: autosave ON.  
- Delay: 2 seconds after the last edit event.
