### PR TITLE
feat: add About section with app overview and visual tour (#173)

### DIFF
--- a/frontend/app/composables/Preferences.ts
+++ b/frontend/app/composables/Preferences.ts
@@ -19,7 +19,6 @@ export const DEFAULT_PREFERENCES = {
     cdn: true as boolean,
     settings: true as boolean,
     home: true as boolean,
-    about: true as boolean,
     importation: false as boolean,
     documents: false as boolean,
     newPage: false as boolean,


### PR DESCRIPTION
This PR implements the “About” section described in issue [#173](https://github.com/Smaug6739/Alexandrie/issues/173)

Summary:

- Added a new /dashboard/about page accessible from the main dashboard or settings.

Includes:

- App description (purpose, core value, and key features)

- Capability overview with structured sections

- Visual tour with improved responsive layout

- Interactive image previews (click to enlarge)

- Updated dashboard homepage to include an “About” tile linking to this section.


Technical details:

- Added a reusable AppAbout component that introduces Alexandrie

- Embedded the new component inside the dashboard settings modal and exposed it via a dedicated /dashboard/about route with breadcrumb support.
