### PR TITLE
fix: typo in preferences

### DIFF
--- a/frontend/app/pages/dashboard/settings/_views/preferences.vue
+++ b/frontend/app/pages/dashboard/settings/_views/preferences.vue
@@ -172,10 +172,10 @@ const options: Array<{ label: string; options: InterfaceOption[] }> = [
     ],
   },
   {
-    label: 'Nabvar',
+    label: 'Navbar',
     options: [
       {
-        label: 'Show items in navbar',
+        label: 'Which items to display in the navbar',
         type: 'groupCheckbox',
         key: 'navbarItems',
         items: {


### PR DESCRIPTION
"nabvar" -> "Navbar", also make the subtext a bit clearer