### PR TITLE
feat: add delete keyboard shortcut on all node pages

### DIFF
--- a/frontend/app/pages/dashboard/categories/[id]/edit.vue
+++ b/frontend/app/pages/dashboard/categories/[id]/edit.vue
@@ -67,16 +67,32 @@ const updateCategory = async () => {
       })
       .catch(e => useNotifications().add({ message: e, title: t('common.status.error'), type: 'error' }));
 };
+
 const deleteCategory = async () => {
+  if (!category.value) return;
   useModal().add(
-    new Modal(shallowRef(DeleteModal), { 
-      props: { 
+    new Modal(shallowRef(DeleteModal), {
+      props: {
         node: category.value,
-        redirectTo: '/dashboard/categories'
-      } 
-    })
+        redirectTo: '/dashboard/categories',
+      },
+    }),
   );
 };
+
+const handleDocumentKeydown = (event: KeyboardEvent) => {
+  if (event.key !== 'Delete') return;
+  event.preventDefault();
+  deleteCategory();
+};
+
+onMounted(() => {
+  document.addEventListener('keydown', handleDocumentKeydown);
+});
+
+onUnmounted(() => {
+  document.removeEventListener('keydown', handleDocumentKeydown);
+});
 </script>
 
 <style scoped lang="scss">

--- a/frontend/app/pages/dashboard/categories/[id]/index.vue
+++ b/frontend/app/pages/dashboard/categories/[id]/index.vue
@@ -6,6 +6,8 @@
 import type { RouteLocationNormalizedLoaded } from 'vue-router';
 import type { Node } from '~/stores';
 
+import NodeDeleteModal from '~/components/Node/Modals/Delete.vue';
+
 definePageMeta({
   breadcrumb: (route: RouteLocationNormalizedLoaded) => {
     return useBreadcrumbs().generateBreadcrumbsById(route.params.id as string);
@@ -24,5 +26,24 @@ watchEffect(() => {
 
 const nodes = computed(() => {
   return nodesStore.getAllChildrens(parent.value?.id || '').filter(d => d.role == 3);
+});
+
+const openDeleteModal = () => {
+  if (!parent.value || !nodesStore.hasPermissions(parent.value, 4)) return;
+  useModal().add(new Modal(shallowRef(NodeDeleteModal), { size: 'small', props: { node: parent.value, redirect: '/dashboard' } }));
+};
+
+const handleDocumentKeydown = (event: KeyboardEvent) => {
+  if (event.key !== 'Delete') return;
+  event.preventDefault();
+  openDeleteModal();
+};
+
+onMounted(() => {
+  document.addEventListener('keydown', handleDocumentKeydown);
+});
+
+onUnmounted(() => {
+  document.removeEventListener('keydown', handleDocumentKeydown);
 });
 </script>

--- a/frontend/app/pages/dashboard/cdn/[id]/index.vue
+++ b/frontend/app/pages/dashboard/cdn/[id]/index.vue
@@ -65,9 +65,26 @@ const updateCategory = async () => {
       })
       .catch(e => useNotifications().add({ message: e, title: 'Error', type: 'error' }));
 };
-const showDeleteModal = () => {
+const openDeleteModal = () => {
+  if (!resource.value) return;
   useModal().add(new Modal(shallowRef(DeleteNodeModal), { props: { nodes: [resource.value], redirectTo: '/dashboard/cdn' }, size: 'small' }));
 };
+
+const showDeleteModal = openDeleteModal;
+
+const handleDocumentKeydown = (event: KeyboardEvent) => {
+  if (event.key !== 'Delete') return;
+  event.preventDefault();
+  openDeleteModal();
+};
+
+onMounted(() => {
+  document.addEventListener('keydown', handleDocumentKeydown);
+});
+
+onUnmounted(() => {
+  document.removeEventListener('keydown', handleDocumentKeydown);
+});
 </script>
 
 <style scoped lang="scss">

--- a/frontend/app/pages/dashboard/cdn/[id]/preview.vue
+++ b/frontend/app/pages/dashboard/cdn/[id]/preview.vue
@@ -21,7 +21,7 @@
             <Icon name="download" display="lg" />
             <p class="hint-tooltip">{{ t('common.actions.download') }}</p>
           </NuxtLink>
-          <button class="btn-icon" @click="showDeleteModal">
+          <button class="btn-icon" @click="openDeleteModal">
             <Icon name="delete" display="lg" />
             <p class="hint-tooltip">{{ t('common.actions.delete') }}</p>
           </button>
@@ -80,9 +80,24 @@ function showDrawioEditor() {
   });
   modalManager.add(modal);
 }
-const showDeleteModal = () => {
+const openDeleteModal = () => {
+  if (!resource.value) return;
   useModal().add(new Modal(shallowRef(DeleteNodeModal), { props: { nodes: [resource.value], redirectTo: '/dashboard/cdn' }, size: 'small' }));
 };
+
+const handleDocumentKeydown = (event: KeyboardEvent) => {
+  if (event.key !== 'Delete') return;
+  event.preventDefault();
+  openDeleteModal();
+};
+
+onMounted(() => {
+  document.addEventListener('keydown', handleDocumentKeydown);
+});
+
+onUnmounted(() => {
+  document.removeEventListener('keydown', handleDocumentKeydown);
+});
 </script>
 <style scoped lang="scss">
 .btn-icon {

--- a/frontend/app/pages/dashboard/docs/[id].vue
+++ b/frontend/app/pages/dashboard/docs/[id].vue
@@ -82,6 +82,16 @@ function showContextMenu(event: MouseEvent) {
   });
 }
 
+const openDeleteModal = () => {
+  if (!node.value) return;
+  useModal().add(
+    new Modal(shallowRef(DeleteNodeModal), {
+      props: { node: node.value, redirectTo: '/dashboard' },
+      size: 'small',
+    }),
+  );
+};
+
 onMounted(() => {
   // Keyboard shortcuts management for navigating between corresponding pages
   const handleDocumentKeydown = (e: KeyboardEvent) => {
@@ -109,14 +119,8 @@ onMounted(() => {
     }
     if (e.key === 'Delete') {
       // Open delete modal on Delete
-      if (!node.value) return;
       e.preventDefault();
-      useModal().add(
-        new Modal(shallowRef(DeleteNodeModal), {
-          props: { node: node.value, redirectTo: '/dashboard' },
-          size: 'small',
-        }),
-      );
+      openDeleteModal();
     }
   };
 


### PR DESCRIPTION
Closes #497

## Changes
Added the `Delete` key shortcut to open the existing delete modal on node pages:

- `categories/[id]/index.vue`
- `categories/[id]/edit.vue`
- `cdn/[id]/preview.vue`
- `cdn/[id]/index.vue`
- `docs/[id].vue`