### PR TITLE
fix: hide Edit diagram button for non-diagram nodes in CDN preview

### DIFF
--- a/frontend/app/pages/dashboard/cdn/[id]/preview.vue
+++ b/frontend/app/pages/dashboard/cdn/[id]/preview.vue
@@ -9,7 +9,7 @@
             <Icon name="edit" display="lg" />
             <p class="hint-tooltip">{{ t('common.actions.edit') }}</p>
           </NuxtLink>
-          <button class="btn-icon" @click="showDrawioEditor">
+          <button v-if="resource.metadata?.drawio" class="btn-icon" @click="showDrawioEditor">
             <Icon name="format/diagrams" display="lg" />
             <p class="hint-tooltip">{{ t('common.actions.edit') }}</p>
           </button>


### PR DESCRIPTION
## Summary

Fixes #498

The "Edit diagram" (drawio) button in the CDN preview page at `/dashboard/cdn/[id]/preview` was displayed for **all** resource types — even non-diagram files like PDFs, images, audio, and video.

## Root Cause

The `<button>` element for the drawio editor at line 12 of `preview.vue` had no conditional rendering check. It was rendered regardless of whether the resource was actually a drawio diagram.

Meanwhile, the preview itself (line 31) and the `Inline.vue` component already correctly check `resource.metadata?.drawio` before showing diagram-specific UI.

## Fix

Added `v-if="resource.metadata?.drawio"` to the Edit diagram button, matching the existing pattern used by:

- `preview.vue` line 31 — diagram preview rendering
- `Inline.vue` line 29 — inline card edit button
- `MarkdownEditor.vue` line 99 — diagram detection logic

## Changes

- `frontend/app/pages/dashboard/cdn/[id]/preview.vue`: 1 line changed (`+1 -1`)

## Testing

- Non-diagram nodes (PDF, image, video, audio): Edit diagram button no longer appears ✅
- Diagram nodes (metadata.drawio = true): Edit diagram button still appears ✅
- Other actions (edit, copy link, download, delete): unaffected ✅