### PR TITLE
feat: add Delete key shortcut to trigger delete modal on nodes pages

### DIFF
--- a/frontend/app/components/Node/ContainerView.vue
+++ b/frontend/app/components/Node/ContainerView.vue
@@ -128,6 +128,23 @@ const openDeleteModal = () => {
   if (props.parent) modals.add(new Modal(shallowRef(NodeDeleteModal), { size: 'small', props: { node: props.parent, redirect: '/dashboard' } }));
 };
 
+// Keyboard shortcut: Delete key triggers delete modal
+function onKeydown(e: KeyboardEvent) {
+  if (e.key === 'Delete' && !isEditingInput(e.target) && props.parent && nodesStore.hasPermissions(props.parent, 4)) {
+    e.preventDefault();
+    openDeleteModal();
+  }
+}
+function isEditingInput(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName;
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
+  return target.isContentEditable;
+}
+
+onMounted(() => window.addEventListener('keydown', onKeydown));
+onUnmounted(() => window.removeEventListener('keydown', onKeydown));
+
 // Kanban functionality
 async function updateKanbanMetadata(metadata: KanbanMetadata) {
   if (!props.parent) return;

--- a/frontend/app/pages/dashboard/cdn/[id]/preview.vue
+++ b/frontend/app/pages/dashboard/cdn/[id]/preview.vue
@@ -82,7 +82,24 @@ function showDrawioEditor() {
 }
 const showDeleteModal = () => {
   useModal().add(new Modal(shallowRef(DeleteNodeModal), { props: { nodes: [resource.value], redirectTo: '/dashboard/cdn' }, size: 'small' }));
-};
+}
+
+// Keyboard shortcut: Delete key triggers delete modal
+function onKeydown(e: KeyboardEvent) {
+  if (e.key === 'Delete' && !isEditingInput(e.target)) {
+    e.preventDefault();
+    showDeleteModal();
+  }
+}
+function isEditingInput(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName;
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
+  return target.isContentEditable;
+}
+
+onMounted(() => window.addEventListener('keydown', onKeydown));
+onUnmounted(() => window.removeEventListener('keydown', onKeydown));
 </script>
 <style scoped lang="scss">
 .btn-icon {


### PR DESCRIPTION
## Summary

Fixes #497

Adds a keyboard shortcut so pressing the **Delete** key triggers the delete modal on node pages, matching the existing button behavior.

## Changes

### ContainerView (`/dashboard/categories/<id>`)
- Added keydown listener that calls `openDeleteModal()` when Delete is pressed
- Respects existing permission gates (`hasPermissions(parent, 4)`)
- Only fires when not currently editing an input/textarea/select or contentEditable element

### CDN Preview (`/dashboard/cdn/<id>/preview`)  
- Same Delete key shortcut pattern
- Calls existing `showDeleteModal()` function
- Same input-focus guard to prevent accidental triggers

## Implementation Details

- Uses `onMounted`/`onUnmounted` lifecycle hooks for clean listener management
- `isEditingInput()` helper prevents firing when user is typing/editing
- Guards: `e.preventDefault()` prevents browser default behavior
- No new dependencies — uses existing Vue composables (auto-imported by Nuxt)

## Files Changed

- `frontend/app/components/Node/ContainerView.vue`: +17 lines
- `frontend/app/pages/dashboard/cdn/[id]/preview.vue`: +17/-1 lines