### PR TITLE
Server-render public pages for SEO & link previews (fixes #556)

### DIFF
--- a/frontend/app/App.vue
+++ b/frontend/app/App.vue
@@ -36,7 +36,7 @@ watch(
 watch(
   interfaceStyle,
   style => {
-    document.documentElement.classList.toggle('glassmorphism', style === 'glassmorphism');
+    if (import.meta.client) document.documentElement.classList.toggle('glassmorphism', style === 'glassmorphism');
   },
   { immediate: true },
 );

--- a/frontend/app/composables/useAppColors.ts
+++ b/frontend/app/composables/useAppColors.ts
@@ -9,6 +9,8 @@ function getAppAccent(index: number = 0, defaultPrimary?: boolean): string {
 
 /** Apply a theme color to CSS custom properties */
 function setAppColor(color: string | number) {
+  // DOM-only side effect; skip during SSR (re-runs on the client via the immediate watcher).
+  if (import.meta.server) return;
   if (typeof color === 'number') {
     color = getAppAccent(color);
   }

--- a/frontend/app/plugins/collections.payload.ts
+++ b/frontend/app/plugins/collections.payload.ts
@@ -1,0 +1,39 @@
+/**
+ * Payload reducers/revivers for the non-POJO structures kept in Pinia state.
+ *
+ * The nodes store holds class instances (`IndexedCollection`, and `Collection`, a
+ * `Map` subclass) in its state. When SSR is enabled Nuxt serialises the Pinia state
+ * into the payload with `devalue`, which throws `Cannot stringify arbitrary non-POJOs`
+ * on class instances. Rather than flattening the data model into plain objects, we
+ * teach `devalue` how to (de)serialise these types: on the server each instance is
+ * reduced to a plain array, and on the client it is rebuilt into the original class.
+ */
+import { IndexedCollection } from '~/helpers/IndexedCollection';
+import { Collection } from '~/stores/collection';
+import type { Node } from '~/stores/db_structures';
+
+export default definePayloadPlugin(() => {
+  // IndexedCollection -> array of nodes (indexes are rebuilt on revive).
+  definePayloadReducer('IndexedCollection', (data: unknown) => {
+    if (!(data instanceof IndexedCollection)) return;
+    return (toRaw(data) as IndexedCollection).toSortedArray().map(n => toRaw(n));
+  });
+  definePayloadReviver('IndexedCollection', (nodes: Node[]) => {
+    const collection = new IndexedCollection();
+    collection.startBulk();
+    for (const node of nodes) collection.set(node.id, node);
+    collection.endBulk();
+    return collection;
+  });
+
+  // Collection (Map subclass) -> array of [key, value] entries.
+  definePayloadReducer('NodeCollection', (data: unknown) => {
+    if (!(data instanceof Collection)) return;
+    return [...(toRaw(data) as Collection<unknown, unknown>).entries()];
+  });
+  definePayloadReviver('NodeCollection', (entries: [unknown, unknown][]) => {
+    const collection = new Collection();
+    for (const [key, value] of entries) collection.set(key, value);
+    return collection;
+  });
+});

--- a/frontend/app/stores/_utils.ts
+++ b/frontend/app/stores/_utils.ts
@@ -25,6 +25,13 @@ let refreshPromise: Promise<void> | null = null;
  */
 function getApiBaseUrl(): string {
   const config = useRuntimeConfig();
+  // During SSR, prefer an internal backend base URL when configured, so server-side
+  // requests don't loop back out through a public proxy/tunnel (which can deadlock when
+  // the frontend and backend are served behind the same reverse proxy). Falls back to
+  // the public base URL, so this is a no-op for typical deployments.
+  if (import.meta.server && config.baseApiInternal) {
+    return `${config.baseApiInternal}/api`;
+  }
   return `${config.public.baseApi}/api`;
 }
 

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -90,7 +90,16 @@ export default defineNuxtConfig({
   /**
    ************************ General ************************
    */
-  ssr: false,
+  ssr: true,
+  routeRules: {
+    // Hybrid rendering: the public surface (landing, login, shared documents) is
+    // server-rendered so links unfurl with per-document metadata and pages are
+    // crawlable. The authenticated dashboard is a client-rendered SPA — it depends
+    // entirely on the user's session (unavailable during SSR) and gains no SEO
+    // benefit, so it stays client-only.
+    '/dashboard': { ssr: false },
+    '/dashboard/**': { ssr: false },
+  },
   compatibilityDate: '2024-07-19',
   devtools: { enabled: process.env.NODE_ENV !== 'production' },
   spaLoadingTemplate: './splash-screen.html',
@@ -146,9 +155,14 @@ export default defineNuxtConfig({
    ************************ Runetime config ************************
    */
   runtimeConfig: {
+    // Server-only: internal backend base URL used for SSR-time requests, to avoid
+    // looping server-side fetches back through a public proxy/tunnel. Set via
+    // NUXT_BASE_API_INTERNAL (e.g. http://backend:8201). Falls back to public baseApi.
+    baseApiInternal: '',
     public: {
       // Base URLs
       baseApi: '',
+      baseUrl: '', // public site URL (NUXT_PUBLIC_BASE_URL) — used for canonical/og:url on public pages
       baseCdn: '',
       cdnEndpoint: '/alexandrie/',
       configDisableLandingPage: '',


### PR DESCRIPTION
## What

Shared public documents (`/doc/:id`) previously unfurled with the generic app title (e.g. *"Alexandrie – Modern Markdown Note-Taking App"*) on platforms that don't run JavaScript — Microsoft Teams, Slack, Discord, social networks — because the app was SPA-only and the per-document `useSeoMeta` never ran server-side. Fixes #556.

## Approach

Reworked to **real SSR**, as requested — but via **hybrid rendering** rather than server-rendering the whole app:

- **`ssr: true`** so the existing per-document `useSeoMeta` on the public doc page renders server-side. No new meta code needed — the page already declared it.
- **`routeRules` keep `/dashboard/**` client-only.** The authenticated dashboard depends entirely on the user's session (cookies/token, unavailable during SSR) and gets no SEO/preview benefit, so it stays a client-rendered SPA — identical behaviour to today. This is the part that isn't safe to SSR (authenticated fetches + the token-refresh path aren't SSR-safe), so it's scoped out rather than half-migrated.
- **Payload reducers/revivers** (`plugins/collections.payload.ts`) for the non-POJO Pinia state — `IndexedCollection`, and `Collection` (a `Map` subclass). Without these, `devalue` throws `Cannot stringify arbitrary non-POJOs` the moment the nodes store is serialised. This teaches devalue to serialise/rehydrate them, **keeping the class-based data model intact** (no flattening of the data structures).
- **SSR guards** for the DOM-only side effects that run through `immediate` watchers (`App.vue` glassmorphism toggle, `useAppColors`) so they no-op on the server and re-run on the client.
- **`getApiBaseUrl` prefers an internal backend URL on the server** (`NUXT_BASE_API_INTERNAL`, e.g. `http://backend:8201`) to stop SSR fetches looping back out through a shared public proxy/tunnel. Falls back to the public base URL, so it's a **no-op for typical deployments**.

Net diff: **+64 / −2** across 5 files.

## Why hybrid, not full-app SSR

You were right that flipping `ssr: true` alone breaks the app. I went through it:
- Composables/global components touch `window`/`document` at setup (`App.vue`, `useAppColors`, …). Guarded the ones on the SSR path.
- The nodes store holds class instances → devalue `Cannot stringify arbitrary non-POJOs`. Solved with reducers.
- **The authenticated dashboard fires session-scoped fetches during SSR** (`nodesStore.init`, `admin.store` `fetchAll`, …) which 401 without cookies, and the token-refresh retry calls `useNuxtApp()` in a context where the instance is gone → unhandled rejection → 500.

That last one is the real wall: making the dashboard SSR *meaningfully* work needs server-side session forwarding + SSR-safe token refresh — a large, risky change for an area that's `noindex` and gains nothing from SSR. Hybrid rendering (a first-class Nuxt feature) puts SSR exactly where it helps (the public, crawlable surface) and leaves the private app as the SPA it already is.

## Testing

Built (`ssr: true`) and served the Nitro output, swept every route:

| Route | Result |
|---|---|
| `/doc/:id` | **200 — SSR**; `<title>`, `og:title`, `og:description`, `og:url` = the document's own values; content in the server HTML |
| `/`, `/about`, `/signup`, `/login`, `/login/*`, `/doc/:id/edit` | 200, server-rendered, no errors |
| `/dashboard`, `/dashboard/{home,docs,categories,settings,teams,admin,import,cdn}` | 200, client SPA shell (as before) |
| non-existent | 404 |

No `devalue` serialisation errors, no unhandled rejections in the server log. Verified a real crawler fetch returns the document title/description; a browser gets the same URL and hydrates the SPA.

Fixes #556
