### PR TITLE
fix(theme): improve glassmorphism theme

### DIFF
--- a/frontend/app/components/AppHeader.vue
+++ b/frontend/app/components/AppHeader.vue
@@ -20,6 +20,7 @@ nav {
 .sign-up {
   border: 1px solid var(--border);
   background: var(--surface-base);
+  backdrop-filter: var(--backdrop-blur) var(--backdrop-saturate);
 
   &:hover {
     outline: 2px solid var(--border);

--- a/frontend/app/components/Sidebar/Sidebar.vue
+++ b/frontend/app/components/Sidebar/Sidebar.vue
@@ -134,6 +134,7 @@ onBeforeUnmount(() => {
   max-height: 100%;
   padding: 0.5rem 0.2rem 0.5rem 0.5rem;
   background: var(--surface-base);
+  backdrop-filter: var(--backdrop-blur) var(--backdrop-saturate);
   overflow-y: auto;
   scrollbar-gutter: stable;
 

--- a/frontend/app/styles/themes/glassmorphism.scss
+++ b/frontend/app/styles/themes/glassmorphism.scss
@@ -18,7 +18,7 @@
 	--overlay-light: rgb(0 0 0 / 20%);
 
 	// Backdrop effects for glassmorphism
-	--backdrop-blur: blur(14px);
+	--backdrop-blur: blur(2px);
 	--backdrop-saturate: saturate(1.6);
 }
 

--- a/frontend/app/styles/themes/glassmorphism.scss
+++ b/frontend/app/styles/themes/glassmorphism.scss
@@ -6,20 +6,20 @@
 
 @mixin glassmorphism-theme {
 	// Border radius
-	--radius-xs: 80px;
-	--radius-sm: 12px;
-	--radius-md: 18px;
-	--radius-lg: 24px;
-	--radius-xl: 24px;
-	--radius-xxl: 28px;
+	--radius-xs: 8px;
+	--radius-sm: 10px;
+	--radius-md: 16px;
+	--radius-lg: 20px;
+	--radius-xl: 22px;
+	--radius-xxl: 26px;
 
 	// Overlay backdrop
 	--overlay-backdrop: rgb(0 0 0 / 50%);
 	--overlay-light: rgb(0 0 0 / 20%);
 
 	// Backdrop effects for glassmorphism
-	--backdrop-blur: blur(2px);
-	--backdrop-saturate: saturate(1);
+	--backdrop-blur: blur(14px);
+	--backdrop-saturate: saturate(1.6);
 }
 
 @mixin glassmorphism-theme-white {
@@ -33,9 +33,9 @@
 
 
 	// Softer borders
-	--border: rgb(223 224 229 / 100%);
-	--border-subtle: rgb(223 225 230 / 20%);
-	--border-strong: rgb(0 0 0 / 10%);
+	--border: rgb(223 224 229 / 45%);
+	--border-subtle: rgb(223 225 230 / 15%);
+	--border-strong: rgb(0 0 0 / 15%);
 
 	// Elevated shadows with slight spread
 	--shadow-sm: 0 2px 8px rgb(0 0 0 / 6%);


### PR DESCRIPTION
Fixes #582

## Changes
- Fixed `--radius-xs: 80px` typo → `8px`, which was causing blockquotes, code
  callouts, and markdown containers to render as over-rounded blobs.
- Rebalanced the rest of the radius scale for visual consistency.
- Increased `--backdrop-blur` (2px → 14px) and fixed `--backdrop-saturate`
  (was `saturate(1)`, a no-op) so the glass effect is actually visible.
- Softened `--border` opacity — it was previously identical to the fully
  opaque white-theme border, undercutting the glass look.
- Added `backdrop-filter` to Sidebar and AppHeader — previously only
  ModalManager used the blur variables, so the glass look only appeared
  in modals.