### PR TITLE
fix(oidc): show configured provider name on login buttons

### DIFF
--- a/frontend/app/components/OIDCProviders.vue
+++ b/frontend/app/components/OIDCProviders.vue
@@ -14,14 +14,14 @@
       >
         <!-- eslint-disable-next-line vue/no-v-html | Safe: icons are statically defined, not user input -->
         <span class="provider-icon" v-html="getProviderConfig(provider.name).icon"></span>
-        <span class="provider-label">{{ getProviderConfig(provider.name).label }}</span>
+        <span class="provider-label">{{ getProviderLabel(provider.name) }}</span>
       </button>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { getProviderConfig } from '~/helpers/oidc-providers';
+import { getProviderConfig, getProviderLabel } from '~/helpers/oidc-providers';
 
 const { providers, isEnabled, isLoading, fetchProviders, loginWithProvider } = useOIDC();
 


### PR DESCRIPTION
The login screen shows "SSO" for any OIDC provider that isn't one of the predefined ones (Google, GitHub, …), ignoring the OIDC_x_PROVIDER_NAME value.

The settings page already displays the correct name because it uses getProviderLabel(), which falls back to the provider's actual name. The login buttons instead use getProviderConfig().label, whose fallback is the hardcoded "SSO". This switches the login buttons to getProviderLabel() as well.

Predefined providers keep their existing label; custom providers now show their configured name. Icon and color are unchanged.

Closes #589