### PR TITLE
feat: add provider name for external SSO providers

### DIFF
--- a/frontend/app/helpers/oidc-providers.ts
+++ b/frontend/app/helpers/oidc-providers.ts
@@ -53,7 +53,12 @@ function getProviderLabel(name: string): string {
 
 function getProviderConfig(name: string) {
   const key = name.toLowerCase();
-  return providerIcons[key] ?? providerIcons['default']!;
+  if (providerIcons[key]) {
+return providerIcons[key];
+  }
+return {
+    ...providerIcons['default']!,
+    label: name,
+  };
 }
-
 export { getProviderIcon, getProviderLabel, getProviderConfig };


### PR DESCRIPTION
Closes #589 

instead of 
```ts
  return providerIcons[key] ?? providerIcons['default']!;
```
change with
```ts

  if (providerIcons[key]) {
return providerIcons[key];
  }
return {
    ...providerIcons['default']!,
    label: name,
  };
}
```

so if its an unknow icon, its replace with main icon