### PR TITLE
fix(editor): layout-independent list shortcuts, always-fenced code block

### DIFF
--- a/frontend/app/components/MarkdownEditor/modules/editorCommands.ts
+++ b/frontend/app/components/MarkdownEditor/modules/editorCommands.ts
@@ -318,21 +318,14 @@ function toggleCodeBlock(view: EditorView, language = ''): void {
     }
   }
 
-  // Not in a code block, create one
-  const isMultiLine = selectedText.includes('\n');
-
-  if (isMultiLine || selectedText.length > 50) {
-    // Use fenced code block for multi-line
-    const insert = `\`\`\`${language}\n${selectedText}\n\`\`\``;
-    view.dispatch({
-      changes: { from, to, insert },
-      selection: { anchor: from + 4 + language.length, head: from + 4 + language.length + selectedText.length },
-    });
-  } else {
-    // Use inline code for short single-line
-    toggleInlineFormat(view, 'code');
-    return;
-  }
+  // Not in a code block, create one. Always a FENCED block (#610): inline code has its own
+  // shortcut and toolbar button, so silently degrading short selections to `inline` made the
+  // explicit code-block action look broken.
+  const insert = `\`\`\`${language}\n${selectedText}\n\`\`\``;
+  view.dispatch({
+    changes: { from, to, insert },
+    selection: { anchor: from + 4 + language.length, head: from + 4 + language.length + selectedText.length },
+  });
   view.focus();
 }
 

--- a/frontend/app/components/MarkdownEditor/modules/editorKeymaps.ts
+++ b/frontend/app/components/MarkdownEditor/modules/editorKeymaps.ts
@@ -233,7 +233,15 @@ export function createKeymaps(commands: { exec: (action: string, payload?: strin
     {
       any: (_view, event) => {
         if (!(event.ctrlKey || event.metaKey) || !event.shiftKey || event.altKey) return false;
-        const digitActions: Record<string, string> = { Digit7: 'orderedList', Digit8: 'list', Digit9: 'taskList' };
+        // The numeric keypad reports its own codes, so it needs listing alongside the digit row.
+        const digitActions: Record<string, string> = {
+          Digit7: 'orderedList',
+          Numpad7: 'orderedList',
+          Digit8: 'list',
+          Numpad8: 'list',
+          Digit9: 'taskList',
+          Numpad9: 'taskList',
+        };
         const action = digitActions[event.code];
         if (!action) return false;
         commands.exec(action);

--- a/frontend/app/components/MarkdownEditor/modules/editorKeymaps.ts
+++ b/frontend/app/components/MarkdownEditor/modules/editorKeymaps.ts
@@ -222,6 +222,25 @@ export function createKeymaps(commands: { exec: (action: string, payload?: strin
         return true;
       },
     },
+
+    // Layout-independent fallback for the Mod-Shift-digit list shortcuts (#610): with Shift held,
+    // the digit row produces a different character on many layouts ('&' on QWERTY, '/' on QWERTZ…)
+    // and some browser/layout combos report keyCodes that CodeMirror can't map back to the digit,
+    // so the name-based bindings above never match. Matching the PHYSICAL key (event.code) works
+    // on every layout; it only runs when no named binding handled the event, so there's no double
+    // dispatch. Returning true makes CodeMirror preventDefault, which also stops the browser's own
+    // Ctrl+digit fallbacks (tab switching) on layouts where digits are shifted.
+    {
+      any: (_view, event) => {
+        if (!(event.ctrlKey || event.metaKey) || !event.shiftKey || event.altKey) return false;
+        const digitActions: Record<string, string> = { Digit7: 'orderedList', Digit8: 'list', Digit9: 'taskList' };
+        const action = digitActions[event.code];
+        if (!action) return false;
+        commands.exec(action);
+        return true;
+      },
+      stopPropagation: true,
+    },
   ];
 
   return markdownKeysmap;


### PR DESCRIPTION
Closes #610

Two distinct root causes:

**1. `Ctrl+Shift+7/8/9` (ordered / bullet / task list) — layout-dependent key matching.** With Shift held, the digit row produces a *different character* on most layouts (`&`/`*`/`(` on QWERTY, `/` on QWERTZ, …), and CodeMirror's name-based bindings recover the digit through `event.keyCode`, which some browser/layout combos report in ways it can't map back. When the binding doesn't match, the key falls through to the browser (tab switching — the "navigator action" you saw on 9). The fix adds an `any` fallback binding in `editorKeymaps.ts` that matches the **physical** keys (`event.code` `Digit7/8/9`) — layout-independent by definition. It only runs when no named binding already handled the event (so no double dispatch), excludes `Ctrl+Alt` so AltGr typing is untouched, and returns true so CodeMirror `preventDefault`s, which also suppresses the browser's own Ctrl+digit fallbacks.

**2. `Ctrl+Shift+C` → inline code.** The binding and dispatch were fine — `toggleCodeBlock` itself silently degraded any selection ≤ 50 chars without a newline to *inline* code (`editorCommands.ts`). Inline code already has its own shortcut (`Ctrl+E`) and toolbar button, so the explicit code-block action now always produces a fenced ```` ``` ```` block (empty selection gives an empty fenced block with the cursor inside, ready to type).

**Verification** — I mounted the app's exact keymap + extension order (`createKeymaps` + default/history/search/closeBrackets, same order as `editorState.ts`) in a live CodeMirror harness and dispatched both real key presses and simulated broken-layout events:

| event | before | after |
|---|---|---|
| real `Ctrl+Shift+7/8/9/C` (QWERTY) | fired | fired once |
| `key:'&', code:Digit7, keyCode:0` (unmappable) | fell through | `orderedList` |
| `key:'/', code:Digit8, keyCode:229` (QWERTZ-ish) | fell through | `list` |
| `key:'ç', code:Digit9, keyCode:192` (AZERTY-ish) | fell through | `taskList` |
| `Ctrl+Alt+Shift+7` (AltGr-style) | — | ignored, not prevented |
| `Ctrl+B` and other named bindings | fired | fired once (no double dispatch) |

`eslint` clean on both files; `nuxt typecheck` shows only the pre-existing errors on main (ImageSelectorModal, SelfHostSteps, request-reset, import/backup).
