### PR TITLE
feat(markdown): add tooltip syntax

### DIFF
--- a/frontend/app/components/MarkdownSyntax.vue
+++ b/frontend/app/components/MarkdownSyntax.vue
@@ -35,6 +35,12 @@
         Syntax: <code v-text="`{color:'color'}(Text to color)`"></code> — example: <code v-text="`{color:blue}(blue)`"></code>
       </p>
 
+      <!-- TOOLTIPS -->
+      <p>
+        <strong>{{ t('markdown.syntax.tooltips') }}:</strong>
+        Syntax: <code v-text="`[Visible text]{tooltip=Hint shown on hover}`"></code> — or a standalone marker: <code v-text="`[[Hint shown on hover]]`"></code>
+      </p>
+
       <p>
         <strong>{{ t('markdown.syntax.titles') }}:</strong>
         Syntax: <code v-text="`# H1`"></code> → <code v-text="`###### H6`"></code>

--- a/frontend/app/helpers/markdown/index.ts
+++ b/frontend/app/helpers/markdown/index.ts
@@ -15,6 +15,7 @@ import { markdownItCheckbox } from './checkbox';
 import { markdownItKatexPlugin } from './katex';
 import { sourceMapPlugin } from './source-map';
 import { internalLinkPlugin } from './internal-links';
+import { tooltipPlugin } from './tooltip';
 
 const md = new MarkdownIt({ html: true, linkify: true });
 md.use(containerPlugin);
@@ -35,6 +36,7 @@ md.use(colorPlugin, {
   enableBracketSyntax: true, // also parse [text]{color=value}
   allowHex: true, // allow #rgb and #rrggbb
 });
+md.use(tooltipPlugin);
 md.use(html5MediaPlugin);
 md.use(svgObjectPlugin);
 md.use(internalLinkPlugin);

--- a/frontend/app/helpers/markdown/tooltip.ts
+++ b/frontend/app/helpers/markdown/tooltip.ts
@@ -1,0 +1,111 @@
+import type MarkdownIt from 'markdown-it';
+import type { StateInline } from 'markdown-it/dist/index.cjs.js';
+
+/**
+ * Tooltips — reuses the application's `.hint-tooltip` CSS (#618).
+ *
+ * Two syntaxes:
+ *   [[hint text]]              → a small "i" marker; hovering it shows the hint
+ *   [visible]{tooltip=hint}    → visible text (inline formatting supported)
+ *                                with the hint shown on hover
+ *
+ * The hint itself is always plain text (escaped); the visible anchor of the
+ * bracket form is tokenized so bold/italic/code keep working inside it.
+ */
+
+/** Try to parse [[hint text]] starting at state.pos (on the first '['). */
+function parseMarkerSyntax(state: StateInline, silent: boolean): boolean {
+  const src = state.src;
+  const start = state.pos;
+
+  if (src.charCodeAt(start) !== 0x5b /* [ */ || src.charCodeAt(start + 1) !== 0x5b) return false;
+
+  const end = src.indexOf(']]', start + 2);
+  if (end === -1) return false;
+
+  const hint = src.slice(start + 2, end).trim();
+  // An empty hint or one spanning lines is not a tooltip.
+  if (!hint || hint.includes('\n')) return false;
+
+  if (!silent) {
+    const token = state.push('tooltip_marker', '', 0);
+    token.meta = { hint };
+  }
+
+  state.pos = end + 2;
+  return true;
+}
+
+/** Try to parse [visible]{tooltip=hint} starting at state.pos (on '['). */
+function parseAnchorSyntax(state: StateInline, silent: boolean): boolean {
+  const src = state.src;
+  const start = state.pos;
+
+  if (src.charCodeAt(start) !== 0x5b /* [ */) return false;
+
+  // Find matching ']' (no nesting, same simplification as the color plugin)
+  const endBracket = src.indexOf(']', start + 1);
+  if (endBracket === -1 || endBracket === start + 1) return false;
+
+  // Must be followed immediately by {tooltip=...}
+  const after = endBracket + 1;
+  if (src.charCodeAt(after) !== 0x7b /* { */) return false;
+
+  const specEnd = src.indexOf('}', after + 1);
+  if (specEnd === -1) return false;
+
+  const spec = src.slice(after + 1, specEnd).trim();
+  const prefix = 'tooltip=';
+  if (!spec.startsWith(prefix)) return false;
+
+  const hint = spec.slice(prefix.length).trim();
+  if (!hint) return false;
+
+  if (!silent) {
+    const open = state.push('tooltip_open', 'span', 1);
+    open.attrSet('class', 'md-tooltip md-tooltip-text');
+    open.attrSet('tabindex', '0');
+
+    // Tokenize the visible anchor so inline formatting keeps working.
+    const oldPos = state.pos;
+    const oldMax = state.posMax;
+    state.pos = start + 1;
+    state.posMax = endBracket;
+    state.md.inline.tokenize(state);
+    state.pos = oldPos;
+    state.posMax = oldMax;
+
+    const hintToken = state.push('tooltip_hint', '', 0);
+    hintToken.meta = { hint };
+
+    state.push('tooltip_close', 'span', -1);
+  }
+
+  state.pos = specEnd + 1;
+  return true;
+}
+
+export function tooltipPlugin(md: MarkdownIt) {
+  md.inline.ruler.before('emphasis', 'tooltip', (state: StateInline, silent: boolean) => {
+    if (state.src.charCodeAt(state.pos) !== 0x5b /* [ */) return false;
+    // [[hint]] first — it also starts with '[' and would otherwise be
+    // half-consumed by the anchor parser.
+    if (parseMarkerSyntax(state, silent)) return true;
+    return parseAnchorSyntax(state, silent);
+  });
+
+  md.renderer.rules.tooltip_marker = (tokens, idx) => {
+    const hint: string = tokens[idx]?.meta?.hint || '';
+    return (
+      `<span class="md-tooltip md-tooltip-marker" tabindex="0">` +
+      `<span class="md-tooltip-icon">i</span>` +
+      `<span class="hint-tooltip">${md.utils.escapeHtml(hint)}</span>` +
+      `</span>`
+    );
+  };
+
+  md.renderer.rules.tooltip_hint = (tokens, idx) => {
+    const hint: string = tokens[idx]?.meta?.hint || '';
+    return `<span class="hint-tooltip">${md.utils.escapeHtml(hint)}</span>`;
+  };
+}

--- a/frontend/app/styles/features/markdown.scss
+++ b/frontend/app/styles/features/markdown.scss
@@ -271,3 +271,46 @@
 		text-decoration: underline;
 	}
 }
+
+/* Markdown tooltips: [[hint]] and [text]{tooltip=hint} (#618).
+   Reuses the global .hint-tooltip look; the reveal is CSS-only because
+   rendered markdown has no component logic behind it. */
+.md-tooltip {
+	position: relative;
+	display: inline-block;
+
+	> .hint-tooltip {
+		width: max-content;
+		max-width: 280px;
+		text-transform: none;
+		white-space: normal;
+	}
+
+	&:hover > .hint-tooltip,
+	&:focus-visible > .hint-tooltip {
+		opacity: 1;
+		visibility: visible;
+		transition-delay: 0s;
+	}
+}
+
+.md-tooltip-text {
+	border-bottom: 1px dotted currentcolor;
+	cursor: help;
+}
+
+.md-tooltip-icon {
+	display: inline-flex;
+	justify-content: center;
+	align-items: center;
+	width: 1rem;
+	height: 1rem;
+	border-radius: 50%;
+	font-size: 0.7rem;
+	font-style: normal;
+	font-weight: bold;
+	color: white;
+	background-color: var(--primary);
+	cursor: help;
+	user-select: none;
+}

--- a/frontend/i18n/locales/de/markdown.ts
+++ b/frontend/i18n/locales/de/markdown.ts
@@ -38,6 +38,7 @@ export default {
     tags: 'Tags',
     title: 'Leitfaden zur Alexandrie-Markdown-Syntax',
     titles: 'Überschriften',
+    tooltips: 'Tooltips',
   },
   table: {
     hoverHint: 'Mit der Maus darüberfahren, um die Größe anzuzeigen',

--- a/frontend/i18n/locales/en/markdown.ts
+++ b/frontend/i18n/locales/en/markdown.ts
@@ -38,6 +38,7 @@ export default {
     tags: 'Tags',
     title: 'Alexandrie Markdown syntax guide',
     titles: 'Headings',
+    tooltips: 'Tooltips',
   },
   table: {
     hoverHint: 'Hover to see size',

--- a/frontend/i18n/locales/fr/markdown.ts
+++ b/frontend/i18n/locales/fr/markdown.ts
@@ -38,6 +38,7 @@ export default {
     tags: 'Tags',
     title: 'Guide de syntaxe Markdown Alexandrie',
     titles: 'Titres',
+    tooltips: 'Info-bulles',
   },
   table: {
     hoverHint: 'Survolez pour voir la taille',

--- a/frontend/i18n/locales/it/markdown.ts
+++ b/frontend/i18n/locales/it/markdown.ts
@@ -38,6 +38,7 @@ export default {
     tags: 'Tag',
     title: 'Guida alla sintassi Markdown di Alexandrie',
     titles: 'Intestazioni',
+    tooltips: 'Tooltip',
   },
   table: {
     hoverHint: 'Passa il mouse per vedere le dimensioni',

--- a/frontend/i18n/locales/ko/markdown.ts
+++ b/frontend/i18n/locales/ko/markdown.ts
@@ -38,6 +38,7 @@ export default {
     tags: '태그',
     title: 'Alexandrie 마크다운 문법 가이드',
     titles: '제목',
+    tooltips: '툴팁',
   },
   table: {
     hoverHint: '마우스를 올리면 크기가 표시됩니다',

--- a/frontend/i18n/locales/uk/markdown.ts
+++ b/frontend/i18n/locales/uk/markdown.ts
@@ -38,6 +38,7 @@ export default {
     tags: 'Теги',
     title: 'Посібник із синтаксису Markdown для «Alexandrie»',
     titles: 'Заголовки',
+    tooltips: 'Підказки',
   },
   table: {
     hoverHint: 'Наведіть курсор, щоб побачити розмір',


### PR DESCRIPTION
Closes #618

Adds a markdown-it plugin (`frontend/app/helpers/markdown/tooltip.ts`) that maps two syntaxes onto the existing `.hint-tooltip` styles:

| Syntax | Renders as |
|---|---|
| `[[Hint shown on hover]]` | a small "i" marker (like `AppHint`) whose hover shows the hint — the form sketched in the issue |
| `[Visible text]{tooltip=Hint}` | the visible text with a dotted underline + `cursor: help`, hint on hover — mirrors the color plugin's `[text]{color=value}` convention |

Details:

- The visible anchor of the bracket form is tokenized, so `[**bold** _anchor_]{tooltip=…}` keeps its formatting; the hint itself is always escaped plain text.
- Reveal is CSS-only (`.md-tooltip:hover/:focus-visible` in `markdown.scss`) since rendered markdown has no component logic; both forms carry `tabindex="0"" so keyboard users can reach the hint too. The base `.hint-tooltip`'s `capitalize`/`nowrap` are overridden inside markdown (arbitrary sentence hints, wrapped at 280px).
- No grammar collisions: the rule registers before `emphasis` like the color plugin and bails without `{tooltip=…}` / `]]`, so `[links](url)`, `[^footnotes]`, `[refs]`, and `[text]{color=…}` parse exactly as before. `[[]]` stays literal.
- Documented in the Markdown syntax guide, with the section label translated in all six locales (en, fr, de, it, ko, uk).

Rendering verified against markdown-it directly for: both syntaxes, nested formatting in anchors, link/footnote/reference non-interference, empty-hint fallthrough, and HTML escaping of hints. `eslint` and `nuxi typecheck` pass.