### PR TITLE
fix: require current password when changing password (#620)

### DIFF
--- a/backend/controllers/access.go
+++ b/backend/controllers/access.go
@@ -26,5 +26,11 @@ func statusFromAccessError(err error) int {
 	if errors.Is(err, permissions.ErrNotFound) {
 		return http.StatusNotFound
 	}
+	if errors.Is(err, permissions.ErrInvalidPassword) {
+		return http.StatusBadRequest
+	}
+	if errors.Is(err, permissions.ErrIncorrectPassword) {
+		return http.StatusUnauthorized
+	}
 	return http.StatusInternalServerError
 }

--- a/backend/controllers/users.controller.go
+++ b/backend/controllers/users.controller.go
@@ -163,7 +163,7 @@ func (ctr *Controller) UpdateUser(c *gin.Context) (int, any) {
 // @Router /users/{id}/password [patch]
 // @Security Authenfification: Auth, {self, admin}
 // @Param id path int true "User ID"
-// @Body Password
+// @Body CurrentPassword, Password
 // @Success 200 {object} Success(string)
 // @Failure 400 {object} Error
 // @Failure 401 {object} Error
@@ -178,13 +178,14 @@ func (ctr *Controller) UpdatePassword(c *gin.Context) (int, any) {
 	}
 
 	var payload struct {
-		Password string `form:"password" json:"password"`
+		CurrentPassword string `form:"current_password" json:"current_password"`
+		Password        string `form:"password" json:"password"`
 	}
 	if err := c.ShouldBind(&payload); err != nil {
 		return http.StatusBadRequest, errors.New("invalid request payload")
 	}
 
-	err = ctr.app.Services.User.UpdatePassword(c.Request.Context(), targetUserId, payload.Password)
+	err = ctr.app.Services.User.UpdatePassword(c.Request.Context(), targetUserId, payload.CurrentPassword, payload.Password)
 	if err != nil {
 		return statusFromAccessError(err), err
 	}

--- a/backend/permissions/service.go
+++ b/backend/permissions/service.go
@@ -30,9 +30,9 @@ func ActorFromContext(ctx context.Context) (Actor, bool) {
 }
 
 var (
-	ErrUnauthorized = errors.New("unauthorized")
-	ErrForbidden    = errors.New("forbidden")
-	ErrNotFound     = errors.New("not found")
+	ErrUnauthorized      = errors.New("unauthorized")
+	ErrForbidden         = errors.New("forbidden")
+	ErrNotFound          = errors.New("not found")
 	ErrInvalidPassword   = errors.New("current password is required")
 	ErrIncorrectPassword = errors.New("current password is incorrect")
 )

--- a/backend/permissions/service.go
+++ b/backend/permissions/service.go
@@ -33,6 +33,8 @@ var (
 	ErrUnauthorized = errors.New("unauthorized")
 	ErrForbidden    = errors.New("forbidden")
 	ErrNotFound     = errors.New("not found")
+	ErrInvalidPassword   = errors.New("current password is required")
+	ErrIncorrectPassword = errors.New("current password is incorrect")
 )
 
 type NodeDecision struct {

--- a/backend/services/user.service.go
+++ b/backend/services/user.service.go
@@ -27,7 +27,7 @@ type UserService interface {
 	SearchPublicUsers(query string) ([]*models.User, error)
 	CreateUser(username string, firstname, lastname, avatar, email string, password *string) (*models.User, error)
 	UpdateUser(ctx context.Context, id types.Snowflake, firstname, lastname, avatar, email *string) (*models.User, error)
-	UpdatePassword(ctx context.Context, id types.Snowflake, newPassword string) error
+	UpdatePassword(ctx context.Context, id types.Snowflake, currentPassword string, newPassword string) error
 	DeleteUser(ctx context.Context, id types.Snowflake, minioService MinioService) error
 	GenerateUniqueUsername(givenName *string, userID types.Snowflake) string
 	LoadAppAdmins()
@@ -151,7 +151,7 @@ func (s *userService) UpdateUser(ctx context.Context, id types.Snowflake, firstn
 	return s.userRepo.Update(id, user)
 }
 
-func (s *userService) UpdatePassword(ctx context.Context, id types.Snowflake, newPassword string) error {
+func (s *userService) UpdatePassword(ctx context.Context, id types.Snowflake, currentPassword string, newPassword string) error {
 	actor, err := actorFromContext(ctx)
 	if err != nil {
 		return err
@@ -162,6 +162,27 @@ func (s *userService) UpdatePassword(ctx context.Context, id types.Snowflake, ne
 
 	if newPassword == "" {
 		return errors.New("password is required")
+	}
+
+	// Only require the current password when users change their own password.
+	// App admins resetting another user's password are exempt (e.g. account recovery).
+	if actor.UserID == id {
+		dbUser, err := s.userRepo.GetByID(id, true)
+		if err != nil || dbUser == nil {
+			return permissions.ErrNotFound
+		}
+
+		// If the user already has a password set, they must confirm it.
+		// Users without a password (e.g. OAuth/SSO-only accounts) are setting
+		// a password for the first time, so no current-password check applies.
+		if dbUser.Password != nil {
+			if currentPassword == "" {
+				return permissions.ErrInvalidPassword
+			}
+			if err := bcrypt.CompareHashAndPassword([]byte(*dbUser.Password), []byte(currentPassword)); err != nil {
+				return permissions.ErrIncorrectPassword
+			}
+		}
 	}
 
 	hash, err := bcrypt.GenerateFromPassword([]byte(newPassword), bcrypt.DefaultCost)

--- a/backend/tests/user_lifecycle_test.go
+++ b/backend/tests/user_lifecycle_test.go
@@ -126,6 +126,41 @@ func TestUserLifeCycle(t *testing.T) {
 		assert.Equal(t, "Unauthorized", r.Message)
 	})
 	// ************************************************************
+	// PATCH /users/@me/password
+	// ************************************************************
+	t.Run("Update password without current password fails", func(t *testing.T) {
+		r := DoPatch(t, client, "/users/@me/password", map[string]any{
+			"password": "new-strong-password",
+		})
+		assert.Equal(t, "error", r.Status)
+		assert.Equal(t, 400, r.StatusCode)
+	})
+	t.Run("Update password with wrong current password fails", func(t *testing.T) {
+		r := DoPatch(t, client, "/users/@me/password", map[string]any{
+			"current_password": "not-the-real-password",
+			"password":         "new-strong-password",
+		})
+		assert.Equal(t, "error", r.Status)
+		assert.Equal(t, 401, r.StatusCode)
+	})
+	t.Run("Update password with correct current password succeeds", func(t *testing.T) {
+		r := DoPatch(t, client, "/users/@me/password", map[string]any{
+			"current_password": "password",
+			"password":         "new-strong-password",
+		})
+		assert.Equal(t, "success", r.Status)
+		assert.Equal(t, 200, r.StatusCode)
+	})
+	t.Run("Login with old password fails after change", func(t *testing.T) {
+		r := LoginAs(t, client, "gnolan", "password")
+		assert.Equal(t, "error", r.Status)
+	})
+	t.Run("Login with new password succeeds", func(t *testing.T) {
+		r := LoginAs(t, client, "gnolan", "new-strong-password")
+		assert.Equal(t, "success", r.Status)
+		assert.Equal(t, 200, r.StatusCode)
+	})
+	// ************************************************************
 	// DELETE /users/@me
 	// ************************************************************
 	t.Run("Delete user", func(t *testing.T) {

--- a/frontend/app/pages/dashboard/settings/_views/_components/SecuritySectionPassword.vue
+++ b/frontend/app/pages/dashboard/settings/_views/_components/SecuritySectionPassword.vue
@@ -3,6 +3,10 @@
     <h3>{{ t('settings.security.password') }}</h3>
     <form @submit.prevent="changePassword">
       <div class="form-group">
+        <label for="current_password">{{ t('settings.security.currentPassword') }}</label>
+        <input id="current_password" v-model="currentPasswordValue" autocomplete="current-password" type="password" required />
+      </div>
+      <div class="form-group">
         <label for="password">{{ t('settings.security.newPassword') }}</label>
         <input id="password" v-model="passwordValue" autocomplete="new-password" type="password" required />
       </div>
@@ -25,6 +29,7 @@ const { t } = useI18nT();
 const notifications = useNotifications();
 
 const passwordValue = ref('');
+const currentPasswordValue = ref('');
 const passwordConfirmValue = ref('');
 const errPasswordNotMatch = ref(false);
 
@@ -32,8 +37,9 @@ const changePassword = async () => {
   if (!userStore.user) return;
   if (passwordValue.value !== passwordConfirmValue.value) return (errPasswordNotMatch.value = true);
   userStore
-    .updatePassword(passwordValue.value)
+    .updatePassword(currentPasswordValue.value, passwordValue.value)
     .then(() => {
+      currentPasswordValue.value = '';
       passwordValue.value = '';
       passwordConfirmValue.value = '';
       errPasswordNotMatch.value = false;

--- a/frontend/app/pages/dashboard/settings/_views/_components/SecuritySectionPassword.vue
+++ b/frontend/app/pages/dashboard/settings/_views/_components/SecuritySectionPassword.vue
@@ -45,7 +45,7 @@ const changePassword = async () => {
       errPasswordNotMatch.value = false;
       notifications.add({ type: 'success', title: t('settings.security.notifications.passwordChanged') });
     })
-    .catch(e => notifications.add({ type: 'error', title: t('settings.security.notifications.passwordError'), message: e.message }));
+    .catch(e => notifications.add({ type: 'error', title: t('settings.security.notifications.passwordError'), message: e }));
 };
 </script>
 <style lang="scss" scoped>

--- a/frontend/app/stores/user.store.ts
+++ b/frontend/app/stores/user.store.ts
@@ -138,9 +138,9 @@ export const useUserStore = defineStore('user', {
       } else throw request.message;
     },
 
-    async updatePassword(newPassword: string) {
+    async updatePassword(currentPassword: string, newPassword: string) {
       if (!this.user) return;
-      const request = await makeRequest(`users/${this.user.id}/password`, 'PATCH', { password: newPassword });
+      const request = await makeRequest(`users/${this.user.id}/password`, 'PATCH', { current_password: currentPassword, password: newPassword });
       if (request.status === 'success') {
         return true;
       } else throw request.message;

--- a/frontend/app/styles/features/markdown.scss
+++ b/frontend/app/styles/features/markdown.scss
@@ -279,15 +279,15 @@
 	position: relative;
 	display: inline-block;
 
-	> .hint-tooltip {
+	>.hint-tooltip {
 		width: max-content;
 		max-width: 280px;
 		text-transform: none;
 		white-space: normal;
 	}
 
-	&:hover > .hint-tooltip,
-	&:focus-visible > .hint-tooltip {
+	&:hover>.hint-tooltip,
+	&:focus-visible>.hint-tooltip {
 		opacity: 1;
 		visibility: visible;
 		transition-delay: 0s;
@@ -307,8 +307,8 @@
 	height: 1rem;
 	border-radius: 50%;
 	font-size: 0.7rem;
-	font-style: normal;
 	font-weight: bold;
+	font-style: normal;
 	color: white;
 	background-color: var(--primary);
 	cursor: help;

--- a/frontend/i18n/locales/de/settings.ts
+++ b/frontend/i18n/locales/de/settings.ts
@@ -225,6 +225,7 @@ export default {
     connected: 'Verbunden',
     connectedAccounts: 'Verbundene Konten',
     connectedAccountsDesc: 'Verknüpfe externe Konten für einfachere Anmeldung.',
+    currentPassword: 'Aktuelles Passwort',
     dangerZone: 'Gefahrenzone',
     dangerZoneDesc: 'Irreversible Aktionen. Mit Vorsicht vorgehen.',
     deleteAccount: 'Konto löschen',

--- a/frontend/i18n/locales/en/settings.ts
+++ b/frontend/i18n/locales/en/settings.ts
@@ -224,6 +224,7 @@ export default {
     connected: 'Connected',
     connectedAccounts: 'Connected accounts',
     connectedAccountsDesc: 'Link external accounts for easier sign-in.',
+    currentPassword: 'Current password',
     dangerZone: 'Danger zone',
     dangerZoneDesc: 'Irreversible actions. Proceed with caution.',
     deleteAccount: 'Delete account',

--- a/frontend/i18n/locales/fr/settings.ts
+++ b/frontend/i18n/locales/fr/settings.ts
@@ -225,6 +225,7 @@ export default {
     connected: 'Connecté',
     connectedAccounts: 'Comptes connectés',
     connectedAccountsDesc: 'Liez des comptes externes pour une connexion plus facile.',
+    currentPassword: 'Mot de passe actuel',
     dangerZone: 'Zone de danger',
     dangerZoneDesc: 'Actions irréversibles. Procédez avec précaution.',
     deleteAccount: 'Supprimer le compte',

--- a/frontend/i18n/locales/it/settings.ts
+++ b/frontend/i18n/locales/it/settings.ts
@@ -224,6 +224,7 @@ export default {
     connected: 'Connesso',
     connectedAccounts: 'Account collegati',
     connectedAccountsDesc: 'Collega account esterni per accedere più facilmente.',
+    currentPassword: 'Password attuale',
     dangerZone: 'Zona di pericolo',
     dangerZoneDesc: 'Azioni irreversibili. Procedi con cautela.',
     deleteAccount: 'Elimina account',

--- a/frontend/i18n/locales/ko/settings.ts
+++ b/frontend/i18n/locales/ko/settings.ts
@@ -224,6 +224,7 @@ export default {
     connected: '연결됨',
     connectedAccounts: '연결된 계정',
     connectedAccountsDesc: '쉬운 로그인을 위해 외부 계정을 연결합니다.',
+    currentPassword: '현재 비밀번호',
     dangerZone: '위험 구역',
     dangerZoneDesc: '되돌릴 수 없는 작업입니다. 주의해서 진행하세요.',
     deleteAccount: '계정 삭제',

--- a/frontend/i18n/locales/uk/settings.ts
+++ b/frontend/i18n/locales/uk/settings.ts
@@ -224,6 +224,7 @@ export default {
     connected: 'Підключено',
     connectedAccounts: "Пов'язані акаунти",
     connectedAccountsDesc: "Прив'яжіть зовнішні акаунти для зручнішого входу.",
+    currentPassword: 'Поточний пароль',
     dangerZone: 'Небезпечна зона',
     dangerZoneDesc: 'Незворотні дії. Будьте обережні.',
     deleteAccount: 'Видалити обліковий запис',


### PR DESCRIPTION
Closes #620

## Summary
Users could previously change their password without confirming their
current one. This adds a current-password check for self-service
password changes.

## Changes
- **Backend**: `UpdatePassword` now requires and verifies the user's
  current password (via bcrypt) before allowing a change, when a user
  is changing their own password.
  - Added `ErrInvalidPassword` (400) and `ErrIncorrectPassword` (401)
    to `permissions`, mapped in `access.go`.
  - `current_password` is a new field on `PATCH /users/:id/password`.
- **Admin exemption**: App admins resetting another user's password
  (account recovery) are not required to provide that user's current
  password — only self-service changes are checked.
- **OAuth/SSO exemption**: Users without an existing password hash
  (e.g. accounts created via OAuth/SSO with no password yet) are not
  required to confirm a current password when setting one for the
  first time.
- **Frontend**: Added a "Current password" field to the security
  settings form, placed first (current → new → confirm), wired through
  the user store and included in the PATCH payload.
- **i18n**: Added `currentPassword` string to all locales (en, de, fr,
  it, ko, uk).

## Tests
Added coverage in `user_lifecycle_test.go`:
- Missing current password → 400
- Wrong current password → 401
- Correct current password → 200, password updated
- Login with old password fails after change
- Login with new password succeeds

## Testing done
- `go build ./...` and `go test ./tests/... -run TestUserLifeCycle -v`
  pass locally.