### PR TITLE
feat(themes): add the Academic document theme

### DIFF
--- a/frontend/app/helpers/constants.ts
+++ b/frontend/app/helpers/constants.ts
@@ -12,6 +12,7 @@ export const DOCUMENT_THEMES = [
   { label: 'Latex style', id: 'latex' },
   { label: 'Latex colored', id: 'latex-colored' },
   { label: 'Modern', id: 'modern' },
+  { label: 'Academic', id: 'academic' },
 ];
 
 // Document visibility options (1 = Private, 3 = Published)

--- a/frontend/app/styles/features/document-theme.scss
+++ b/frontend/app/styles/features/document-theme.scss
@@ -433,3 +433,223 @@
 		}
 	}
 }
+
+// Academic — for research papers, theses and scientific writing. Serif body at
+// a comfortable reading measure, numbered headings, tighter leading than Modern,
+// and figure/table captions that read as part of the document rather than UI.
+.academic-theme {
+	max-width: 100%;
+	padding: 0 0.5rem;
+	font-family: 'Libertinus Serif', 'LMRoman10', Georgia, serif !important;
+	font-size: 17px;
+	line-height: 1.65;
+	color: var(--text-body);
+	text-align: justify;
+	hyphens: auto;
+
+	.header-anchor {
+		display: none;
+	}
+
+	// Automatic section numbering, the way a paper is structured. Counters are
+	// reset on the container so every document numbers from 1.
+	counter-reset: section;
+
+	h1 {
+		margin: 0 0 1.5rem;
+		font-size: 1.9em;
+		font-weight: 700;
+		line-height: 1.25;
+		text-align: center;
+	}
+
+	h2 {
+		counter-reset: subsection;
+		margin: 2rem 0 0.75rem;
+		font-size: 1.35em;
+		font-weight: 700;
+
+		&::before {
+			counter-increment: section;
+			content: counter(section) '. ';
+		}
+	}
+
+	h3 {
+		margin: 1.25rem 0 0.5rem;
+		font-size: 1.12em;
+		font-weight: 600;
+
+		&::before {
+			counter-increment: subsection;
+			content: counter(section) '.' counter(subsection) '. ';
+		}
+	}
+
+	h4 {
+		margin: 1rem 0 0.5rem;
+		font-size: 1em;
+		font-style: italic;
+		font-weight: 600;
+	}
+
+	p {
+		width: 100%;
+		margin: 0;
+		padding: 0.35em 0;
+	}
+
+	// Indent successive paragraphs instead of spacing them out — the typographic
+	// convention in printed papers.
+	p + p {
+		text-indent: 1.5em;
+	}
+
+	a {
+		color: var(--primary);
+		text-decoration: none;
+
+		&:hover {
+			text-decoration: underline;
+		}
+	}
+
+	code,
+	pre {
+		font-family: $font-mono;
+		font-size: 0.88em;
+		color: var(--text-body);
+	}
+
+	pre {
+		overflow-x: auto;
+		padding: 0.75rem 1rem;
+		border: 1px solid var(--border-color);
+		border-radius: var(--radius-sm);
+		text-align: left;
+		hyphens: none;
+	}
+
+	blockquote {
+		margin: 1.25rem 2rem;
+		padding: 0;
+		border: none;
+		font-size: 0.95em;
+		font-style: italic;
+		color: var(--text-muted);
+	}
+
+	ul,
+	ol {
+		margin: 0.5em 0;
+		padding-left: 1.75rem;
+		text-align: left;
+
+		li {
+			margin: 0.25em 0;
+		}
+	}
+
+	img {
+		display: block;
+		max-width: 100%;
+		margin: 1.5rem auto 0.5rem;
+	}
+
+	// Figure and table captions: small, centred, numbered.
+	figure {
+		margin: 1.5rem 0;
+
+		figcaption {
+			margin-top: 0.5rem;
+			font-size: 0.85em;
+			color: var(--text-muted);
+			text-align: center;
+		}
+	}
+
+	table {
+		width: 100%;
+		margin: 1.5em 0;
+		border-collapse: collapse;
+		font-size: 0.92em;
+		text-align: left;
+
+		// Booktabs-style rules: horizontal only, no vertical lines.
+		th,
+		td {
+			padding: 0.45em 0.6em;
+			border: none;
+			border-bottom: 1px solid var(--border-color);
+		}
+
+		thead th {
+			border-top: 2px solid var(--text-body);
+			border-bottom: 1px solid var(--text-body);
+			font-weight: 700;
+		}
+
+		tbody tr:last-child td {
+			border-bottom: 2px solid var(--text-body);
+		}
+	}
+
+	.custom-block {
+		margin: 1.25rem 0;
+		padding: 0.75rem 1rem;
+		border-left: 3px solid var(--grey);
+		border-radius: 0;
+		font-size: 0.95em;
+		text-align: left;
+		background-color: var(--surface-raised);
+
+		&.info,
+		&.blue {
+			border-left-color: var(--blue);
+		}
+
+		&.success,
+		&.green {
+			border-left-color: var(--green);
+		}
+
+		&.warning,
+		&.yellow {
+			border-left-color: var(--yellow);
+		}
+
+		&.danger,
+		&.red {
+			border-left-color: var(--red);
+		}
+
+		&.teal {
+			border-left-color: var(--teal);
+		}
+
+		&.purple {
+			border-left-color: var(--purple);
+		}
+
+		.custom-block-title {
+			margin-bottom: 0.35rem;
+			font-variant: small-caps;
+			font-weight: 700;
+			letter-spacing: 0.02em;
+		}
+
+		.custom-block-content p {
+			margin: 0.35em 0;
+			text-indent: 0;
+		}
+	}
+
+	.katex {
+		font-size: 18px;
+
+		.text {
+			font-family: 'Libertinus Math', serif !important;
+			font-size: 14px;
+		}
+	}
+}

--- a/frontend/app/styles/features/document-theme.scss
+++ b/frontend/app/styles/features/document-theme.scss
@@ -445,15 +445,15 @@
 	line-height: 1.65;
 	color: var(--text-body);
 	text-align: justify;
+
+	// Automatic section numbering, the way a paper is structured. Counters are
+	// reset on the container so every document numbers from 1.
+	counter-reset: section;
 	hyphens: auto;
 
 	.header-anchor {
 		display: none;
 	}
-
-	// Automatic section numbering, the way a paper is structured. Counters are
-	// reset on the container so every document numbers from 1.
-	counter-reset: section;
 
 	h1 {
 		margin: 0 0 1.5rem;
@@ -464,14 +464,14 @@
 	}
 
 	h2 {
-		counter-reset: subsection;
 		margin: 2rem 0 0.75rem;
 		font-size: 1.35em;
 		font-weight: 700;
+		counter-reset: subsection;
 
 		&::before {
-			counter-increment: section;
 			content: counter(section) '. ';
+			counter-increment: section;
 		}
 	}
 
@@ -481,16 +481,16 @@
 		font-weight: 600;
 
 		&::before {
-			counter-increment: subsection;
 			content: counter(section) '.' counter(subsection) '. ';
+			counter-increment: subsection;
 		}
 	}
 
 	h4 {
 		margin: 1rem 0 0.5rem;
 		font-size: 1em;
-		font-style: italic;
 		font-weight: 600;
+		font-style: italic;
 	}
 
 	p {
@@ -522,12 +522,12 @@
 	}
 
 	pre {
-		overflow-x: auto;
 		padding: 0.75rem 1rem;
 		border: 1px solid var(--border-color);
 		border-radius: var(--radius-sm);
 		text-align: left;
 		hyphens: none;
+		overflow-x: auto;
 	}
 
 	blockquote {
@@ -571,9 +571,9 @@
 	table {
 		width: 100%;
 		margin: 1.5em 0;
-		border-collapse: collapse;
 		font-size: 0.92em;
 		text-align: left;
+		border-collapse: collapse;
 
 		// Booktabs-style rules: horizontal only, no vertical lines.
 		th,
@@ -633,8 +633,8 @@
 
 		.custom-block-title {
 			margin-bottom: 0.35rem;
-			font-variant: small-caps;
 			font-weight: 700;
+			font-variant: small-caps;
 			letter-spacing: 0.02em;
 		}
 


### PR DESCRIPTION
Adds the **Academic** theme from the #591 checklist — for research, scientific and academic documents.

One PR per theme, as the issue asks. Both files from the issue are touched: the `.academic-theme` block in `document-theme.scss` and the entry in `DOCUMENT_THEMES` in `helpers/constants.ts`.

## Design
Rather than just recolouring, it applies the typographic conventions a paper actually uses:

- **Serif body**, justified with `hyphens: auto`, tighter leading (1.65) than Modern.
- **Automatic section numbering** via CSS counters — `h2` renders `1.`, `2.` …, `h3` renders `1.1.`, `1.2.` …, with `subsection` reset on each `h2` and `section` reset on the theme container, so every document starts at 1.
- **Indented paragraphs** — `p + p` gets a `text-indent` instead of extra vertical space, the printed-paper convention. The first paragraph after a heading is deliberately not indented.
- **Centred title**, italic `h4` run-in headings.
- **Booktabs-style tables** — horizontal rules only (heavy above/below the header and at the end, light between rows), no vertical lines.
- Quotes are italic and inset rather than bordered; `custom-block` titles use small-caps and keep the existing colour variants.
- Code blocks opt out of `justify`/`hyphens`, which would otherwise mangle them.

Everything uses the existing CSS variables, so it follows light/dark automatically.

## Verified
Compiled the stylesheet with `sass` and asserted the emitted rules rather than just eyeballing the source — the counter chain (`counter-reset`/`counter-increment`/nested `content`), the `p + p` indent, the booktabs header rule, the absence of vertical cell borders, and the justified serif body all come through in the compiled CSS.

Happy to adjust the numbering (or drop it behind a variant) if you'd rather headings stayed unnumbered.

Part of #591