### PR TITLE
feat(themes): add the Github document theme

### DIFF
--- a/frontend/app/helpers/constants.ts
+++ b/frontend/app/helpers/constants.ts
@@ -14,6 +14,7 @@ export const DOCUMENT_THEMES = [
   { label: 'Modern', id: 'modern' },
   { label: 'Academic', id: 'academic' },
   { label: 'Material', id: 'material' },
+  { label: 'Github', id: 'github' },
 ];
 
 // Document visibility options (1 = Private, 3 = Published)

--- a/frontend/app/styles/features/document-theme.scss
+++ b/frontend/app/styles/features/document-theme.scss
@@ -854,7 +854,7 @@
 	hr {
 		margin: 2rem 0;
 		border: none;
-		border-top: 1px solid var(--border-color);
+		border-top: 1px solid var(--border);
 	}
 
 	// Data table: no vertical rules, a divider under the header, 500-weight
@@ -872,7 +872,7 @@
 		td {
 			padding: 0.75rem 1rem;
 			border: none;
-			border-bottom: 1px solid var(--border-color);
+			border-bottom: 1px solid var(--border);
 			text-align: left;
 		}
 
@@ -941,5 +941,209 @@
 
 	.katex {
 		font-size: 1.05em;
+	}
+}
+
+.github-theme {
+	max-width: 100%;
+	padding: 0 0.5rem;
+	font-family: $font-sans !important;
+	font-size: 16px;
+	line-height: 1.6;
+	color: var(--text-body);
+
+	.header-anchor {
+		display: none;
+	}
+
+	h1,
+	h2,
+	h3,
+	h4,
+	h5,
+	h6 {
+		margin: 24px 0 16px;
+		font-weight: 600;
+		line-height: 1.25;
+	}
+
+	// GitHub's signature: a hairline rule under the top two heading levels.
+	h1 {
+		padding-bottom: 0.3em;
+		border-bottom: 1px solid var(--border);
+		font-size: 2em;
+	}
+
+	h2 {
+		padding-bottom: 0.3em;
+		border-bottom: 1px solid var(--border);
+		font-size: 1.5em;
+	}
+
+	h3 {
+		font-size: 1.25em;
+	}
+
+	h4 {
+		font-size: 1em;
+	}
+
+	h5 {
+		font-size: 0.875em;
+	}
+
+	h6 {
+		font-size: 0.85em;
+		color: var(--text-muted);
+	}
+
+	p {
+		width: 100%;
+		margin: 0 0 16px;
+	}
+
+	a {
+		color: var(--primary);
+		text-decoration: none;
+
+		&:hover {
+			text-decoration: underline;
+		}
+	}
+
+	// Inline code is a tinted chip; a fenced block is a bordered, padded panel.
+	code {
+		padding: 0.2em 0.4em;
+		border-radius: var(--radius-sm);
+		font-family: $font-mono;
+		font-size: 85%;
+		background-color: var(--surface-raised);
+	}
+
+	pre {
+		margin: 0 0 16px;
+		padding: 16px;
+		border: 1px solid var(--border);
+		border-radius: var(--radius-md);
+		font-size: 85%;
+		line-height: 1.45;
+		background-color: var(--surface-raised);
+		overflow-x: auto;
+
+		code {
+			padding: 0;
+			font-size: 100%;
+			background-color: transparent;
+		}
+	}
+
+	blockquote {
+		margin: 0 0 16px;
+		padding: 0 1em;
+		border-left: 0.25em solid var(--border);
+		color: var(--text-muted);
+	}
+
+	ul,
+	ol {
+		margin: 0 0 16px;
+		padding-left: 2em;
+
+		li {
+			margin: 0.25em 0;
+		}
+	}
+
+	img {
+		max-width: 100%;
+		margin: 0.5rem 0;
+		border-radius: var(--radius-sm);
+	}
+
+	hr {
+		height: 0.25em;
+		margin: 24px 0;
+		padding: 0;
+		border: 0;
+		background-color: var(--border);
+	}
+
+	// GitHub-flavoured tables: fully bordered cells with zebra striping on even rows.
+	table {
+		display: block;
+		width: max-content;
+		max-width: 100%;
+		margin: 0 0 16px;
+		border-collapse: collapse;
+		overflow-x: auto;
+
+		th,
+		td {
+			padding: 6px 13px;
+			border: 1px solid var(--border);
+		}
+
+		th {
+			font-weight: 600;
+		}
+
+		tr:nth-child(2n) {
+			background-color: var(--surface-raised);
+		}
+	}
+
+	// GitHub alerts: a coloured left rail plus a coloured, bold title and no fill — mapping Alexandrie's
+	// container colours onto GitHub's Note / Tip / Warning / Caution palette.
+	.custom-block {
+		margin: 0 0 16px;
+		padding: 0.5em 1em;
+		border: 0;
+		border-left: 0.25em solid var(--border);
+		color: var(--text-body);
+		background-color: transparent;
+
+		.custom-block-title {
+			margin: 0 0 0.5em;
+			font-weight: 600;
+			color: var(--text-primary);
+		}
+
+		.custom-block-content > :last-child {
+			margin-bottom: 0;
+		}
+
+		&.blue,
+		&.grey,
+		&.teal {
+			border-left-color: var(--blue);
+
+			.custom-block-title {
+				color: var(--blue);
+			}
+		}
+
+		&.green {
+			border-left-color: var(--green);
+
+			.custom-block-title {
+				color: var(--green);
+			}
+		}
+
+		&.yellow {
+			border-left-color: var(--yellow);
+
+			.custom-block-title {
+				color: var(--yellow);
+			}
+		}
+
+		&.red {
+			border-left-color: var(--red);
+
+			.custom-block-title {
+				color: var(--red);
+			}
+		}
 	}
 }


### PR DESCRIPTION
Adds the **Github** theme from the #591 checklist — *inspired from the github interface*.

One PR per theme as the issue asks; only the two files it lists are touched.

## Design
Aimed at the look of a rendered README rather than a loose approximation, so the recognisable details are all there:

- **Rules under `h1` and `h2`** (`border-bottom` + `padding-bottom: 0.3em`) — the single most identifiable part of the style.
- **Inline code as a tinted chip** (`0.2em 0.4em`, 85% size), with the chip explicitly **reset inside `pre`** so fenced blocks don't end up with a chip-on-panel double background. That's the detail most GitHub-style themes get wrong.
- **Bordered tables with zebra striping** on even rows, and `display: block; overflow-x: auto` so a wide table scrolls instead of breaking the layout.
- Blockquote with the `0.25em` left border, and the thick `hr`.
- GitHub-ish spacing rhythm (`24px` above headings, `16px` below blocks).

Callouts use a coloured left rule rather than a heavy fill — closest to GitHub's own alert style, and it keeps them legible in greyscale.

Everything uses existing CSS variables (`--surface-raised`, `--border-color`, …), so light/dark follow automatically rather than hard-coding GitHub's hex values.

## Verified
- `npx stylelint` clean, including `order/properties-order`.
- Compiled with `sass` and asserted the emitted rules: both heading rules, the inline-code chip, the `pre code` background reset, the zebra striping and the bordered cells.

Part of #591