### PR TITLE
feat(cdn): add bulk parent selection

### DIFF
--- a/frontend/app/components/Node/Resource/CDN.vue
+++ b/frontend/app/components/Node/Resource/CDN.vue
@@ -45,6 +45,13 @@
           <div class="bulk-actions">
             <span class="selected-count">{{ selected.length }}</span>
             <span class="divider" />
+            <AppSelect
+              v-model="bulkParentId"
+              :items="parentNodes"
+              :placeholder="t('common.placeholder.parent')"
+              size="240px"
+              @update:model-value="parentId => bulkSetParent(selected, parentId)"
+            />
             <span @click="bulkDelete(selected)"><Icon name="delete" fill="var(--text-secondary)" class="action-btn" /></span>
           </div>
         </template>
@@ -83,6 +90,7 @@
 import ResourceContextMenu from '~/components/Node/Action/ResourceContextMenu.vue';
 import DeleteNodeModal from '~/components/Node/Modals/Delete.vue';
 import { readableFileSize, resolvePreviewUrl } from '~/helpers/resources';
+import { assignParent } from '~/helpers/resources-parent';
 import { resolveNodeColor } from '~/helpers/node';
 
 import type { Field } from '~/components/DataTable.vue';
@@ -109,6 +117,7 @@ const notifications = useNotifications();
 
 const view = ref<'list' | 'table'>('list');
 const dataTable = ref<{ selectedRows: Field[] } | null>(null);
+const bulkParentId = ref<string | number>('');
 const selectedFiles = ref<File[]>([]);
 const fileLinks = ref<string[]>([]);
 const isLoading = ref(false);
@@ -117,6 +126,7 @@ const dropComponent = ref();
 const filter = ref('');
 
 const MAX_STORAGE = 1024 * 1024 * 1024; // 1 GB in bytes
+const parentNodes = tree.getTreeUpToRole(3);
 
 const nodes = computed(() => {
   if (props.parentId)
@@ -213,6 +223,23 @@ const deleteResource = async (node: Node) => {
 const bulkDelete = async (lines: Field[]) => {
   const resources = lines.map(line => line.action?.data as Node);
   modals.add(new Modal(shallowRef(DeleteNodeModal), { props: { nodes: resources, redirectTo: '/dashboard/cdn' }, size: 'small' }));
+};
+
+const bulkSetParent = async (lines: Field[], parentId: string | number) => {
+  if (!parentId) return;
+
+  const resources = assignParent(
+    lines.map(line => line.action?.data as Node),
+    parentId,
+  );
+  try {
+    await Promise.all(resources.map(resource => nodesStore.update(resource)));
+    bulkParentId.value = '';
+    if (dataTable.value) dataTable.value.selectedRows = [];
+    notifications.add({ title: t('common.actions.update'), type: 'success' });
+  } catch (e) {
+    notifications.add({ message: String(e), title: 'Error', type: 'error' });
+  }
 };
 
 // Shortcuts

--- a/frontend/app/helpers/resources-parent.test.ts
+++ b/frontend/app/helpers/resources-parent.test.ts
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+import { assignParent } from './resources-parent';
+
+describe('assignParent', () => {
+  test('returns resources assigned to the selected parent without mutating the originals', () => {
+    const resources = [
+      { id: 'resource-1', parent_id: 'old-parent' },
+      { id: 'resource-2' },
+    ];
+
+    const updated = assignParent(resources, 'document-1');
+
+    assert.deepEqual(updated, [
+      { id: 'resource-1', parent_id: 'document-1' },
+      { id: 'resource-2', parent_id: 'document-1' },
+    ]);
+    assert.deepEqual(resources, [
+      { id: 'resource-1', parent_id: 'old-parent' },
+      { id: 'resource-2' },
+    ]);
+  });
+});

--- a/frontend/app/helpers/resources-parent.ts
+++ b/frontend/app/helpers/resources-parent.ts
@@ -1,0 +1,3 @@
+export function assignParent<T extends { parent_id?: string }>(resources: T[], parentId: string | number): T[] {
+  return resources.map(resource => ({ ...resource, parent_id: String(parentId) }));
+}


### PR DESCRIPTION
## Summary

I added a parent selector to the CDN table's bulk-action toolbar so I can move several selected resources under the same category or document in one operation. After the updates finish, I clear both the parent selector and the table selection.

I also added a focused regression test for applying a parent without mutating the original resource objects.

## Validation

I ran:

- `bun test app/helpers/resources-parent.test.ts`
- `bun x eslint app/components/Node/Resource/CDN.vue app/helpers/resources-parent.ts app/helpers/resources-parent.test.ts`
- `bun x stylelint app/components/Node/Resource/CDN.vue`
- `bun run build`
- `git diff --check`

I also ran `bun run typecheck`. It currently reports the existing MarkdownIt typing errors under `app/helpers/markdown/`; it reports no diagnostics in the changed files.

Fixes #575
