### PR TITLE
fix(markdown): make the code-block copy button survive its failure modes

### DIFF
--- a/frontend/app/helpers/markdown/code-block.ts
+++ b/frontend/app/helpers/markdown/code-block.ts
@@ -30,18 +30,82 @@ export const copyCodePlugin = (md: MarkdownIt) => {
 // Icon svg "copy"
 const COPY_ICON = `<svg xmlns="http://www.w3.org/2000/svg" height="18px" viewBox="0 -960 960 960" width="18px"><path d="M160-80q-33 0-56.5-23.5T80-160v-480q0-33 23.5-56.5T160-720h80v-80q0-33 23.5-56.5T320-880h480q33 0 56.5 23.5T880-800v480q0 33-23.5 56.5T800-240h-80v80q0 33-23.5 56.5T640-80H160Zm160-240h480v-480H320v480Z"/></svg>`;
 
+/**
+ * The code to copy for a given button.
+ *
+ * `data-code` is the fast path, but it is baked into `content_compiled` when the
+ * document is saved, so a document stored before the attribute existed (or saved by a
+ * path that dropped it) has an empty one. That is the "re-adding the block makes it
+ * work again" symptom: the fresh block carries the attribute, the stored one does not.
+ * Falling back to the rendered `<code>` text means the button works off whatever is
+ * actually on screen.
+ */
+const codeFor = (btn: HTMLElement): string => {
+  const fromAttr = btn.dataset.code;
+  if (fromAttr) return fromAttr;
+  return btn.closest('.code-block-wrapper')?.querySelector('pre code')?.textContent ?? '';
+};
+
+/** Copy `text`, returning whether it actually landed on the clipboard. */
+const writeToClipboard = async (text: string): Promise<boolean> => {
+  // navigator.clipboard is undefined outside a secure context — a self-hosted
+  // instance reached over plain http:// on a LAN address, for instance. Reading
+  // `.writeText` off it threw synchronously and aborted the handler before it could
+  // give any feedback at all.
+  if (navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // Rejects when the document is not focused, or when permission is refused.
+      // Fall through to the legacy path rather than failing outright.
+    }
+  }
+
+  try {
+    const staging = document.createElement('textarea');
+    staging.value = text;
+    staging.setAttribute('readonly', '');
+    // Off-screen but still selectable; `display: none` would break execCommand.
+    staging.style.cssText = 'position:fixed;top:-1000px;opacity:0;';
+    document.body.appendChild(staging);
+    staging.select();
+    const ok = document.execCommand('copy');
+    staging.remove();
+    return ok;
+  } catch {
+    return false;
+  }
+};
+
 // Registered at module scope, so it must be guarded for SSR: the markdown pipeline
 // is imported on server-rendered pages (e.g. the public document reader) where
 // `document` does not exist.
 if (import.meta.client) {
-  document.addEventListener('click', e => {
-    const btn = (e.target as HTMLElement)?.closest('.code-copy-btn') as HTMLButtonElement | null;
-    if (!btn) return;
+  // Capture phase: a click handler on an ancestor of the code block that calls
+  // stopPropagation would otherwise stop this from ever running, and the markdown is
+  // rendered inside components that do bind their own click handlers.
+  document.addEventListener(
+    'click',
+    e => {
+      const btn = (e.target as HTMLElement)?.closest('.code-copy-btn') as HTMLButtonElement | null;
+      if (!btn) return;
 
-    const code = btn.dataset.code ?? '';
-    navigator.clipboard.writeText(code);
-
-    btn.classList.add('copied');
-    setTimeout(() => btn.classList.remove('copied'), 800);
-  });
+      // The whole body is guarded: an exception here used to leave the button with no
+      // feedback, which reads to the user as "the copy button is broken".
+      void (async () => {
+        let ok: boolean;
+        try {
+          ok = await writeToClipboard(codeFor(btn));
+        } catch {
+          ok = false;
+        }
+        // Always say something. Silence is what made this look like a dead button.
+        const state = ok ? 'copied' : 'copy-failed';
+        btn.classList.add(state);
+        setTimeout(() => btn.classList.remove(state), 800);
+      })();
+    },
+    true,
+  );
 }

--- a/frontend/app/styles/features/markdown.scss
+++ b/frontend/app/styles/features/markdown.scss
@@ -197,6 +197,19 @@
 	fill: #2ac27a;
 }
 
+// A copy that could not complete — no clipboard API (non-secure context) and the
+// legacy fallback refused too. Says so rather than looking like a dead button.
+.code-copy-btn.copy-failed {
+	fill: #e5484d;
+}
+
+// While either state is showing, keep the button visible even if the pointer has
+// moved off the block: the feedback is the point.
+.code-copy-btn.copied,
+.code-copy-btn.copy-failed {
+	opacity: 1;
+}
+
 // *************** CARDS BLOCKS **************** //
 .block {
 	display: flex;


### PR DESCRIPTION
Refs #642

## Up front: I could not reproduce your exact sequence

So this is a fix for every failure mode I could find by reading the handler, rather than a confirmed root cause. **Each one independently produces the reported symptom** ("no indication that anything was copied"), and two of them explain the odd parts of your report. Happy to iterate if it still misbehaves.

## What was wrong

The old handler had no way to report trouble and three ways to die silently:

**1. `navigator.clipboard` is undefined outside a secure context.**
```js
navigator.clipboard.writeText(code);   // TypeError if clipboard is undefined
btn.classList.add('copied');           // never reached
```
Reading `.writeText` off `undefined` throws **synchronously**, so the handler aborted *before* adding the `copied` class. That's exactly "clicked, no indication, nothing copied." A self-hosted instance reached over plain `http://` on a LAN address is not a secure context.

**2. The promise was never awaited.** A rejection — document not focused, permission refused — still painted the success state, or showed nothing at all.

**3. `data-code` is baked into `content_compiled` at save time.** A document stored before the attribute existed, or saved by a path that dropped it, has an empty one and copies an empty string. **I think this is your "if I re-add the block it starts working again":** the fresh block carries the attribute, the stored one doesn't. It also explains why refreshing doesn't help — the stored HTML is what's refreshed.

## What changed

| | |
|---|---|
| **DOM fallback** | when `data-code` is empty, read `pre code`'s `textContent` — copies what's actually on screen, not what was stored |
| **Secure-context guard** | `navigator.clipboard?.writeText`, awaited, with a staged-`textarea` + `execCommand('copy')` fallback |
| **Always give feedback** | new `.copy-failed` state (red) when the copy genuinely couldn't happen; both states force `opacity: 1` so the feedback survives the pointer leaving the block |
| **Capture phase** | the markdown renders inside components that bind their own click handlers (`ContentCompiled`'s `@click`); a `stopPropagation` anywhere above the block would stop the document listener from ever running |
| **try/catch around the body** | no future exception can leave the button mute again |

The silent-failure part is the bit I'd argue for regardless of root cause: a copy button that does nothing and says nothing is unfixable from the user's side.

## Verification

- `eslint` — clean on `code-block.ts`
- `stylelint` — clean on `markdown.scss`
- `nuxi typecheck` — **77 errors, identical on an unmodified `main`.** They're the pre-existing `markdown-it` type-import style (`import type { MarkdownIt } from 'markdown-it'` → `TS2614`) used across every helper in `app/helpers/markdown/`, including `code-block.ts` before this change. I left them alone; happy to send a separate PR fixing the import style across that directory if you want it.

There's no test runner in `frontend/`, so this wasn't exercised by an automated test — if you'd like one I'd need to add vitest + a DOM environment, which felt like a bigger call than this fix.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)