### PR TITLE
fix: remove duplicated state in markdown editor and allow dynamic category change

### DIFF
--- a/frontend/app/components/MarkdownEditor/MarkdownEditor.vue
+++ b/frontend/app/components/MarkdownEditor/MarkdownEditor.vue
@@ -62,8 +62,11 @@ const resourcesStore = useResourcesStore();
 const nodesStore = useNodesStore();
 const preferences = usePreferencesStore();
 
-const props = defineProps<{ doc?: Partial<Node>; public?: boolean }>();
-const emit = defineEmits(['save', 'exit', 'autoSave']);
+defineProps<{ public?: boolean }>();
+const emit = defineEmits<{
+  (e: 'save' | 'autoSave', doc: Partial<Node>): void;
+  (e: 'exit'): void;
+}>();
 
 const editorContainer = ref<HTMLDivElement>();
 const markdownPreviewComponent = ref<InstanceType<typeof NodeDocumentContentCompiled>>();
@@ -81,10 +84,7 @@ const scrollSync = createScrollSync({
 
 const resolveNode = (id: string) => nodesStore.getById(id)?.name;
 
-const document = ref<Partial<Node>>({
-  ...props.doc,
-  content_compiled: compile(props.doc?.content || '', resolveNode),
-});
+const document = defineModel<Partial<Node>>({ required: true });
 
 const commands = createCommands({
   getView: () => editorView.value as EditorView | null,
@@ -96,7 +96,7 @@ const commands = createCommands({
 
 const uploadsHandlers = createUploadsHandlers({
   resourcesStore,
-  nodeId: props.doc?.id,
+  nodeId: document.value.id,
   insertText: (t: string) => commands.exec('insertText', t),
 });
 

--- a/frontend/app/pages/(public)/doc/[id]/edit.vue
+++ b/frontend/app/pages/(public)/doc/[id]/edit.vue
@@ -1,6 +1,6 @@
 <template>
   <ClientOnly>
-    <LazyMarkdownEditor v-if="document && !error" :doc="document" public @save="data => save(data)" @auto-save="data => autoSave(data)" @exit="exit" />
+    <LazyMarkdownEditor v-if="document && !error" v-model="document" public @save="data => save(data)" @auto-save="data => autoSave(data)" @exit="exit" />
   </ClientOnly>
 </template>
 <script lang="ts" setup>
@@ -32,15 +32,15 @@ const { data: document, error } = await useAsyncData(`public-doc-e-${route.param
   }
   return undefined;
 });
-function save(doc: Node) {
+function save(doc: Partial<Node>) {
   store
-    .update(doc)
+    .update(doc as Node)
     .then(() => notifications.add({ title: 'Document successfully updated', type: 'success' }))
     .catch(e => notifications.add({ message: e, title: 'Error', type: 'error' }));
 }
 
-function autoSave(doc: Node) {
-  store.update(doc);
+function autoSave(doc: Partial<Node>) {
+  store.update(doc as Node);
 }
 
 const exit = () => router.push(`/doc/${nodeId}`);

--- a/frontend/app/pages/dashboard/docs/edit/[id].vue
+++ b/frontend/app/pages/dashboard/docs/edit/[id].vue
@@ -1,5 +1,5 @@
 <template>
-  <LazyMarkdownEditor v-if="node" :doc="node" @save="data => save(data)" @auto-save="autoSave" @exit="exit" />
+  <LazyMarkdownEditor v-if="node" v-model="node" @save="data => save(data)" @auto-save="autoSave" @exit="exit" />
 </template>
 <script lang="ts" setup>
 import type { Node } from '~/stores';
@@ -27,13 +27,13 @@ watchEffect(async () => {
 });
 
 // Actions
-const save = (doc: Node) => {
+const save = (doc: Partial<Node>) => {
   store
-    .update(doc)
+    .update(doc as Node)
     .then(() => notifications.add({ title: 'Document successfully updated', type: 'success' }))
     .catch(e => notifications.add({ message: e, title: 'Error', type: 'error' }));
 };
-const autoSave = (doc: Node) => store.update(doc);
+const autoSave = (doc: Partial<Node>) => store.update(doc as Node);
 
 const exit = () => {
   const redirect = route.query.redirect as string | undefined;

--- a/frontend/app/pages/dashboard/docs/new.vue
+++ b/frontend/app/pages/dashboard/docs/new.vue
@@ -1,15 +1,11 @@
 <template>
-  <LazyMarkdownEditor :doc="document" @save="data => save(data)" @exit="exit" @auto-save="savePending" />
+  <LazyMarkdownEditor v-model="document" @save="data => save(data)" @exit="exit" @auto-save="savePending" />
 </template>
 <script lang="ts" setup>
 import localForage from 'localforage';
 import type { Node } from '~/stores';
 
 definePageMeta({ breadcrumb: { i18n: 'common.actions.new' } });
-
-interface NewDocumentQuery {
-  parent_id?: string;
-}
 
 const store = useNodesStore();
 
@@ -22,16 +18,17 @@ const pendingNode = await localForage.getItem<Node>('pendingNode');
 
 let saved = false;
 
-const routeQuery = computed<NewDocumentQuery>(() => route.query);
-const defaultParent = computed(() => routeQuery.value.parent_id || sidebar.workspaceId.value || undefined);
-const document = computed<Partial<Node>>(() => ({
-  accessibility: 1,
-  parent_id: ['root', 'shared'].includes(defaultParent.value || '') ? undefined : defaultParent.value,
-  role: 3,
-  ...pendingNode,
-}));
+const defaultParent = computed(() => (route.query.parent_id as string) || sidebar.workspaceId.value || undefined);
+const document = computed<Partial<Node>>(() => {
+  return {
+    accessibility: 1,
+    role: 3,
+    ...pendingNode,
+    parent_id: ['root', 'shared'].includes(defaultParent.value || '') ? undefined : defaultParent.value,
+  };
+});
 
-function save(doc: Node) {
+function save(doc: Partial<Node>) {
   store
     .post(doc)
     .then(async d => {
@@ -43,7 +40,7 @@ function save(doc: Node) {
     .catch(e => notifications.add({ message: e, title: 'Error', type: 'error' }));
 }
 
-function savePending(node: Node) {
+function savePending(node: Partial<Node>) {
   if (saved) return;
   localForage.setItem('pendingNode', toRaw(node));
 }


### PR DESCRIPTION
Closes #684 