### PR TITLE
feat(themes): add the Terminal document theme

### DIFF
--- a/frontend/app/helpers/constants.ts
+++ b/frontend/app/helpers/constants.ts
@@ -15,6 +15,7 @@ export const DOCUMENT_THEMES = [
   { label: 'Academic', id: 'academic' },
   { label: 'Material', id: 'material' },
   { label: 'Minimal', id: 'minimal' },
+  { label: 'Terminal', id: 'terminal' },
 ];
 
 // Document visibility options (1 = Private, 3 = Published)

--- a/frontend/app/styles/features/document-theme.scss
+++ b/frontend/app/styles/features/document-theme.scss
@@ -1108,3 +1108,312 @@
 		}
 	}
 }
+
+.terminal-theme {
+	max-width: 100%;
+	padding: 0 0.75rem;
+	font-family: $font-mono !important;
+	font-size: 15px;
+	line-height: 1.7;
+	color: var(--text-body);
+	letter-spacing: -0.01em;
+
+	.header-anchor {
+		display: none;
+	}
+
+	h1,
+	h2,
+	h3,
+	h4,
+	h5,
+	h6 {
+		font-family: $font-mono !important;
+		font-weight: 700;
+		line-height: 1.3;
+	}
+
+	// Terminal command line prompt headers
+	h1 {
+		margin: 2rem 0 1.25rem;
+		padding-bottom: 0.5rem;
+		border-bottom: 1px dashed var(--border);
+		font-size: 1.75em;
+		color: var(--text-primary);
+
+		&::before {
+			font-weight: 400;
+			color: var(--primary);
+			content: "$ ";
+		}
+	}
+
+	h2 {
+		margin: 1.75rem 0 1rem;
+		padding-bottom: 0.25rem;
+		border-bottom: 1px solid var(--border);
+		font-size: 1.35em;
+		color: var(--text-primary);
+
+		&::before {
+			font-weight: 400;
+			color: var(--primary);
+			opacity: 0.85;
+			content: "## ";
+		}
+	}
+
+	h3 {
+		margin: 1.5rem 0 0.75rem;
+		font-size: 1.15em;
+		color: var(--text-primary);
+
+		&::before {
+			font-weight: 400;
+			color: var(--text-muted);
+			content: "### ";
+		}
+	}
+
+	h4 {
+		margin: 1.25rem 0 0.5rem;
+		font-size: 1em;
+		color: var(--text-primary);
+
+		&::before {
+			font-weight: 400;
+			color: var(--text-muted);
+			content: "#### ";
+		}
+	}
+
+	h5,
+	h6 {
+		margin: 1rem 0 0.5rem;
+		font-size: 0.9em;
+		color: var(--text-muted);
+
+		&::before {
+			font-weight: 400;
+			content: "// ";
+		}
+	}
+
+	p {
+		width: 100%;
+		margin: 0.75em 0;
+	}
+
+	a {
+		color: var(--primary);
+		text-decoration: underline;
+		text-underline-offset: 0.2em;
+
+		&:hover {
+			color: var(--text-primary);
+			background-color: var(--surface-raised);
+		}
+	}
+
+	// Monospace inline code badge
+	code {
+		padding: 0.15em 0.45em;
+		border: 1px solid var(--border);
+		border-radius: var(--radius-xs);
+		font-family: $font-mono !important;
+		font-size: 0.9em;
+		color: var(--primary);
+		background-color: var(--surface-raised);
+	}
+
+	// Terminal code console block
+	pre {
+		margin: 1.25rem 0;
+		padding: 1rem 1.25rem;
+		border: 1px solid var(--border);
+		border-radius: var(--radius-sm);
+		font-size: 0.9em;
+		line-height: 1.5;
+		background-color: var(--surface-raised);
+		overflow-x: auto;
+
+		code {
+			padding: 0;
+			border: 0;
+			font-size: 100%;
+			color: inherit;
+			background-color: transparent;
+		}
+	}
+
+	// Command output blockquote with pipe-line aesthetic
+	blockquote {
+		margin: 1.25rem 0;
+		padding: 0.6rem 1rem;
+		border-left: 3px solid var(--primary);
+		border-radius: 0 var(--radius-xs) var(--radius-xs) 0;
+		color: var(--text-muted);
+		background-color: var(--surface-raised);
+
+		&::before {
+			display: block;
+			margin-bottom: 0.25rem;
+			font-size: 0.8em;
+			font-weight: 600;
+			color: var(--primary);
+			opacity: 0.75;
+			content: "[output]";
+		}
+
+		p {
+			margin: 0.25em 0;
+		}
+	}
+
+	// Command list with prompt bullets
+	ul {
+		margin: 1rem 0;
+		padding-left: 1.5rem;
+		list-style: none;
+
+		li {
+			position: relative;
+			margin: 0.35em 0;
+
+			&::before {
+				position: absolute;
+				left: -1.25rem;
+				font-weight: bold;
+				color: var(--primary);
+				content: "›";
+			}
+		}
+	}
+
+	ol {
+		margin: 1rem 0;
+		padding-left: 2rem;
+
+		li {
+			margin: 0.35em 0;
+		}
+	}
+
+	img {
+		max-width: 100%;
+		margin: 1rem 0;
+		border: 1px solid var(--border);
+		border-radius: var(--radius-xs);
+	}
+
+	hr {
+		height: 0;
+		margin: 2rem 0;
+		border: 0;
+		border-top: 1px dashed var(--border);
+	}
+
+	// ASCII terminal grid table
+	table {
+		display: block;
+		width: max-content;
+		max-width: 100%;
+		margin: 1.25rem 0;
+		border: 1px solid var(--border);
+		border-collapse: collapse;
+		overflow-x: auto;
+
+		th,
+		td {
+			padding: 0.45rem 0.85rem;
+			border: 1px solid var(--border);
+		}
+
+		th {
+			font-size: 0.85em;
+			font-weight: 700;
+			color: var(--text-primary);
+			text-transform: uppercase;
+			letter-spacing: 0.05em;
+			background-color: var(--surface-raised);
+		}
+
+		tr:nth-child(2n) {
+			background-color: var(--surface-raised);
+		}
+	}
+
+	// CLI status log blocks
+	.custom-block {
+		margin: 1.25rem 0;
+		padding: 0.75rem 1rem;
+		border: 1px solid var(--border);
+		border-left-width: 4px;
+		border-radius: var(--radius-xs);
+		color: var(--text-body);
+		background-color: var(--surface-raised);
+
+		.custom-block-title {
+			margin: 0 0 0.4em;
+			font-size: 0.85em;
+			font-weight: 700;
+			color: var(--text-primary);
+			text-transform: uppercase;
+			letter-spacing: 0.05em;
+		}
+
+		.custom-block-content > :last-child {
+			margin-bottom: 0;
+		}
+
+		&.blue,
+		&.grey,
+		&.teal {
+			border-left-color: var(--blue);
+
+			.custom-block-title {
+				color: var(--blue);
+
+				&::before {
+					content: "[INFO] ";
+				}
+			}
+		}
+
+		&.green {
+			border-left-color: var(--green);
+
+			.custom-block-title {
+				color: var(--green);
+
+				&::before {
+					content: "[OK] ";
+				}
+			}
+		}
+
+		&.yellow {
+			border-left-color: var(--yellow);
+
+			.custom-block-title {
+				color: var(--yellow);
+
+				&::before {
+					content: "[WARN] ";
+				}
+			}
+		}
+
+		&.red {
+			border-left-color: var(--red);
+
+			.custom-block-title {
+				color: var(--red);
+
+				&::before {
+					content: "[ERROR] ";
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Adds the **Terminal** document theme — a distinct, hacker/developer-inspired retro console theme designed to be completely distinct from all existing sans-serif and serif document themes.

### Distinctive Design Highlights
- **Full Monospace Rhythm**: Built completely on monospace font (`$font-mono`) with tighter `-0.01em` tracking and balanced `1.7` line height for extended reading.
- **CLI Prompt Headings**: 
  - `h1` with `$ ` primary prompt and dashed divider.
  - `h2` with `## ` sub-prompt.
  - `h3` ~ `h6` with `### ` / `// ` code-comment styling.
- **Console Blockquotes**: Styled as command outputs (`[output]`) with solid accent left rail.
- **Prompt List Bullets**: Bullet lists rendered with terminal command prompt `›` glyphs.
- **ASCII Terminal Tables**: Full-grid borders with styled uppercase headers and alternating row fills.
- **CLI Status Log Callouts**: Admonitions styled as CLI logs with prefix tags (`[INFO]`, `[OK]`, `[WARN]`, `[ERROR]`).
- **Native Light/Dark Support**: Built strictly on existing CSS variables (`--primary`, `--border`, `--surface-raised`, `--text-body`...).

### Verification
- Fully compliant with `order/properties-order` in `pnpm lint:css`.
- `pnpm lint` passed with 0 errors.

Part of #591