### PR TITLE
fix(ui): hide active Sign up and Login buttons on their respective routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # File storage
 minio.exe
 minio
+minio-data
 
 # Backend
 main.exe

--- a/frontend/app/components/AppHeader.vue
+++ b/frontend/app/components/AppHeader.vue
@@ -2,14 +2,15 @@
   <nav>
     <NuxtLinkLocale to="/" class="secondary">{{ t('public.nav.home') }}</NuxtLinkLocale>
     <div>
-      <NuxtLinkLocale to="/login" class="primary">{{ t('public.nav.login') }}</NuxtLinkLocale>
-      <NuxtLinkLocale to="/signup" class="secondary">{{ t('public.nav.signup') }}</NuxtLinkLocale>
+      <NuxtLinkLocale v-if="!route.path.includes('/login')" to="/login" class="primary">{{ t('public.nav.login') }}</NuxtLinkLocale>
+      <NuxtLinkLocale v-if="!route.path.includes('/signup')" to="/signup" class="secondary">{{ t('public.nav.signup') }}</NuxtLinkLocale>
     </div>
   </nav>
 </template>
 
 <script setup lang="ts">
 const { t } = useI18nT();
+const route = useRoute();
 </script>
 
 <style scoped lang="scss">


### PR DESCRIPTION
This PR resolves a UI/UX issue on the public landing pages where the "Sign up" and "Login" buttons in the top navbar remained visible and clickable even when the user was already on those exact routes.

Previously, clicking these buttons while on the route produced no visual feedback or action, which could cause user confusion.

Changes:

Conditionally hide the "Sign up" button when the user is on the /signup route.
Conditionally hide the "Login" button when the user is on the /login route.
Added minio-data to .gitignore to prevent local object storage files from being accidentally tracked.

Closes  #702 