### PR TITLE
feat(ui): add new advanced nodes view with bulk actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # File storage
 minio.exe
 minio
+minio-data
 
 # Backend
 main.exe

--- a/frontend/app/components/AppHeader.vue
+++ b/frontend/app/components/AppHeader.vue
@@ -2,14 +2,15 @@
   <nav>
     <NuxtLinkLocale to="/" class="secondary">{{ t('public.nav.home') }}</NuxtLinkLocale>
     <div>
-      <NuxtLinkLocale to="/login" class="primary">{{ t('public.nav.login') }}</NuxtLinkLocale>
-      <NuxtLinkLocale to="/signup" class="secondary">{{ t('public.nav.signup') }}</NuxtLinkLocale>
+      <NuxtLinkLocale v-if="!route.path.includes('/login')" to="/login" class="primary">{{ t('public.nav.login') }}</NuxtLinkLocale>
+      <NuxtLinkLocale v-if="!route.path.includes('/signup')" to="/signup" class="secondary">{{ t('public.nav.signup') }}</NuxtLinkLocale>
     </div>
   </nav>
 </template>
 
 <script setup lang="ts">
 const { t } = useI18nT();
+const route = useRoute();
 </script>
 
 <style scoped lang="scss">

--- a/frontend/app/components/AppTagInput.vue
+++ b/frontend/app/components/AppTagInput.vue
@@ -133,6 +133,8 @@ function removeTag(tag: string) {
   selectedTags.value = selectedTags.value.filter(t => t !== tag);
   emit('update:modelValue', selectedTags.value.join(','));
 }
+
+defineExpose({ addTag });
 </script>
 
 <style scoped lang="scss">

--- a/frontend/app/components/DataTable.vue
+++ b/frontend/app/components/DataTable.vue
@@ -10,7 +10,7 @@
         <thead>
           <tr>
             <th>
-              <input type="checkbox" style="width: 20px" :checked="selectedRows.length > 0" @change="toggleSelectAll" />
+              <input type="checkbox" style="width: 20px" :checked="selectedRows.length === data.length && data.length > 0" @change="toggleSelectAll" />
             </th>
             <th v-for="header in headers" :key="header.key" :class="header.align && `align-${header.align}`">
               <span>{{ header.label }}</span>

--- a/frontend/app/components/Node/AdvancedView.vue
+++ b/frontend/app/components/Node/AdvancedView.vue
@@ -1,0 +1,147 @@
+<template>
+  <div class="line-container" style="padding-top: 10px;">
+    <DataTable ref="tableRef" :headers="headers" :rows="rows">
+      <template #bulk-actions="{ selected }">
+        <div class="bulk-actions">
+          <span class="selected-count">{{ selected.length }}</span>
+          <span class="divider" />
+          <AppSelect
+            v-model="bulkParentId"
+            :items="parentNodes"
+            :placeholder="t('common.placeholder.parent')"
+            size="240px"
+            @update:model-value="parentId => bulkSetParent(selected, parentId)"
+          />
+          <span class="divider" />
+          <span @click="bulkDelete(selected)"><Icon name="delete" fill="var(--text-secondary)" class="action-btn" /></span>
+        </div>
+      </template>
+      <template #name="{ cell }">
+        <div style="display:flex;align-items:center;gap:8px;">
+          <Icon :name="asNode(cell?.data)?.icon || 'files'" />
+          <NuxtLink :to="`/dashboard/docs/${asNode(cell?.data)?.id}`">{{ asNode(cell?.data)?.name }}</NuxtLink>
+        </div>
+      </template>
+      <template #tags="{ cell }">
+        <NodeTagList v-if="cell?.data" :tags="asNode(cell.data).tags" class="tags" />
+      </template>
+      <template #action="{ cell }">
+        <NuxtLink :to="`/dashboard/docs/${asNode(cell?.data)?.id}`"><Icon name="edit" style="margin-right: 10px" /></NuxtLink>
+        <span style="cursor: pointer" @click="() => deleteNode(asNode(cell?.data))"><Icon name="delete" /></span>
+      </template>
+    </DataTable>
+  </div>
+</template>
+
+<script setup lang="ts">
+import NodeDeleteModal from '~/components/Node/Modals/Delete.vue';
+import { assignParent } from '~/helpers/resources-parent';
+import type { Node } from '~/stores';
+import type { Field } from '~/components/DataTable.vue';
+
+const props = defineProps<{ nodes: Node[] }>();
+
+const asNode = (data: unknown) => data as Node;
+const nodesStore = useNodesStore();
+const modals = useModal();
+const { getAppAccent } = useAppColors();
+const { t } = useI18nT();
+const { numericDate } = useDateFormatters();
+const notifications = useNotifications();
+const tree = useNodesTree();
+const parentNodes = tree.getTreeUpToRole(3);
+
+const tableRef = ref<{ selectedRows: Field[] } | null>(null);
+const bulkParentId = ref<string | number>('');
+
+const headers = [
+  { key: 'name', label: t('common.labels.name') },
+  { key: 'type', label: t('common.labels.type') },
+  { key: 'parent', label: t('common.labels.parent') },
+  { key: 'tags', label: 'Tags' },
+  { key: 'date', label: t('common.labels.date') },
+  { key: 'action', label: t('common.labels.action') },
+];
+
+const rows: ComputedRef<Field[]> = computed(() =>
+  props.nodes.map(res => {
+    const parent = res.parent_id ? nodesStore.getById(res.parent_id) : null;
+    return {
+      action: { data: res, type: 'slot' },
+      date: { content: numericDate(res.updated_timestamp), type: 'text' },
+      name: { data: res, type: 'slot' },
+      parent: { content: parent ? `<tag class="${getAppAccent(parent.color as number, true)}">${parent.name}</tag>` : '', type: 'html' },
+      tags: { data: res.tags, type: 'slot' },
+      type: { content: `<tag class="primary">Document</tag>`, type: 'html' },
+    };
+  }),
+);
+
+// Actions
+const bulkDelete = async (lines: Field[]) => {
+  const nodes = lines.map(line => line.action?.data as Node);
+  modals.add(new Modal(shallowRef(NodeDeleteModal), { props: { nodes: nodes, redirectTo: '/dashboard' }, size: 'small' }));
+};
+
+const bulkSetParent = async (lines: Field[], parentId: string | number) => {
+  if (!parentId) return;
+  const nodesToUpdate = assignParent(
+    lines.map(line => line.action?.data as Node),
+    parentId as string,
+  );
+  try {
+    await Promise.all(nodesToUpdate.map(node => nodesStore.update(node)));
+    bulkParentId.value = '';
+    if (tableRef.value) tableRef.value.selectedRows = [];
+    notifications.add({ title: t('common.actions.update'), type: 'success' });
+  } catch (e) {
+    notifications.add({ message: String(e), title: 'Error', type: 'error' });
+  }
+};
+
+const deleteNode = (node: Node) => {
+  modals.add(new Modal(shallowRef(NodeDeleteModal), { props: { node: node, redirectTo: '/dashboard' }, size: 'small' }));
+};
+</script>
+
+<style scoped lang="scss">
+.bulk-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+}
+
+.action-btn {
+  cursor: pointer;
+
+  &:hover {
+    background: var(--surface-transparent);
+  }
+}
+
+.selected-count {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 32px;
+  height: 34px;
+  padding: 4px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xs);
+  font-size: 12px;
+  font-weight: bold;
+  color: var(--text-secondary);
+}
+
+.divider {
+  height: 32px;
+  margin-left: 4px;
+  border-left: 1px solid var(--border);
+}
+
+.line-container {
+  display: flex;
+  flex-direction: column;
+}
+</style>

--- a/frontend/app/components/Node/ContainerView.vue
+++ b/frontend/app/components/Node/ContainerView.vue
@@ -57,8 +57,42 @@
     </Teleport>
     <!-- Content based on view mode -->
     <div v-if="filteredNodes.length" class="node-content">
+      <!-- Advanced DataTable View -->
+      <div v-if="view === 'advanced'" class="line-container" style="padding-top: 10px;">
+        <DataTable ref="tableRef" :headers="headers" :rows="rows">
+          <template #bulk-actions="{ selected }">
+            <div class="bulk-actions">
+              <span class="selected-count">{{ selected.length }}</span>
+              <span class="divider" />
+              <AppSelect
+                v-model="bulkParentId"
+                :items="parentNodes"
+                :placeholder="t('common.placeholder.parent')"
+                size="240px"
+                @update:model-value="parentId => bulkSetParent(selected, parentId)"
+              />
+              <span class="divider" />
+              <span @click="bulkDelete(selected)"><Icon name="delete" fill="var(--text-secondary)" class="action-btn" /></span>
+            </div>
+          </template>
+          <template #name="{ cell }">
+            <div style="display:flex;align-items:center;gap:8px;">
+              <Icon :name="asNode(cell?.data)?.icon || 'files'" />
+              <NuxtLink :to="`/dashboard/docs/${asNode(cell?.data)?.id}`">{{ asNode(cell?.data)?.name }}</NuxtLink>
+            </div>
+          </template>
+          <template #tags="{ cell }">
+            <NodeTagList v-if="cell?.data" :tags="asNode(cell.data).tags" class="tags" />
+          </template>
+          <template #action="{ cell }">
+            <NuxtLink :to="`/dashboard/docs/${asNode(cell?.data)?.id}`"><Icon name="edit" style="margin-right: 10px" /></NuxtLink>
+            <span style="cursor: pointer" @click="() => deleteNode(asNode(cell?.data))"><Icon name="delete" /></span>
+          </template>
+        </DataTable>
+      </div>
+
       <!-- Table/List View -->
-      <div v-if="view === 'table'" class="line-container">
+      <div v-else-if="view === 'table'" class="line-container">
         <NodeListInline v-for="document of filteredNodes" :key="document.id" :document="document" class="line-item" />
       </div>
 
@@ -76,6 +110,12 @@
         @update-metadata="updateKanbanMetadata"
         @create-document="createDocumentInColumn"
       />
+
+      <!-- Fallback View (Just in case view is undefined or unrecognized) -->
+      <div v-else class="line-container fallback-view">
+        <div style="padding: 20px; color: red;">DEBUG: View is unrecognized or undefined. Current value: {{ view }}</div>
+        <NodeListInline v-for="document of filteredNodes" :key="document.id" :document="document" class="line-item" />
+      </div>
     </div>
 
     <NoContent v-else-if="!nodesStore.isFetching" :title="t('nodes.container.noDocuments')" :description="t('nodes.container.noDocumentsDescription')">
@@ -93,10 +133,14 @@ import RemoveSharedNode from '~/components/Node/Modals/RemoveShared.vue';
 import NodeMetadataModal from '~/components/Node/Modals/Metadata.vue';
 import KanbanBoard, { type KanbanMetadata } from '~/components/Kanban/Board.vue';
 import ResetBoardModal from '../Kanban/ResetBoard.modal.vue';
+import { assignParent } from '~/helpers/resources-parent';
 import type { ViewMode } from '~/components/ViewSelection.vue';
 import type { Node } from '~/stores';
+import type { Field } from '~/components/DataTable.vue';
 
 const props = defineProps<{ parent?: Node; nodes: Node[]; parentId?: string }>();
+
+const asNode = (data: any) => data as Node;
 
 const nodesStore = useNodesStore();
 const nodesPermissionsStore = useNodesPermissionsStore();
@@ -107,8 +151,23 @@ const { getAppAccent } = useAppColors();
 const { t } = useI18nT();
 const router = useRouter();
 const slots = useSlots();
+const { numericDate } = useDateFormatters();
+const notifications = useNotifications();
+const tree = useNodesTree();
+const parentNodes = tree.getTreeUpToRole(3);
 
 const connectedId = userStore.user?.id;
+const tableRef = ref<{ selectedRows: Field[] } | null>(null);
+const bulkParentId = ref<string | number>('');
+
+const headers = [
+  { key: 'name', label: t('common.labels.name') },
+  { key: 'type', label: t('common.labels.type') },
+  { key: 'parent', label: t('common.labels.parent') },
+  { key: 'tags', label: 'Tags' },
+  { key: 'date', label: t('common.labels.date') },
+  { key: 'action', label: t('common.labels.action') },
+];
 const view = ref<ViewMode>();
 const filteredNodes = ref<Node[]>(props.nodes);
 const kanbanBoard = ref<InstanceType<typeof KanbanBoard> | null>(null);
@@ -120,7 +179,46 @@ watch(
   { immediate: true },
 );
 
+const rows: ComputedRef<Field[]> = computed(() =>
+  filteredNodes.value.map(res => {
+    const parent = res.parent_id ? nodesStore.getById(res.parent_id) : null;
+    return {
+      action: { data: res, type: 'slot' },
+      date: { content: numericDate(res.updated_timestamp), type: 'text' },
+      name: { data: res, type: 'slot' },
+      parent: { content: parent ? `<tag class="${getAppAccent(parent.color as number, true)}">${parent.name}</tag>` : '', type: 'html' },
+      tags: { data: res.tags, type: 'slot' },
+      type: { content: `<tag class="primary">Document</tag>`, type: 'html' },
+    };
+  }),
+);
+
 // Actions
+const bulkDelete = async (lines: Field[]) => {
+  const nodes = lines.map(line => line.action?.data as Node);
+  modals.add(new Modal(shallowRef(NodeDeleteModal), { props: { nodes: nodes, redirectTo: '/dashboard' }, size: 'small' }));
+};
+
+const bulkSetParent = async (lines: Field[], parentId: string | number) => {
+  if (!parentId) return;
+  const nodesToUpdate = assignParent(
+    lines.map(line => line.action?.data as Node),
+    parentId as string,
+  );
+  try {
+    await Promise.all(nodesToUpdate.map(node => nodesStore.update(node)));
+    bulkParentId.value = '';
+    if (tableRef.value) tableRef.value.selectedRows = [];
+    notifications.add({ title: t('common.actions.update'), type: 'success' });
+  } catch (e) {
+    notifications.add({ message: String(e), title: 'Error', type: 'error' });
+  }
+};
+
+const deleteNode = (node: Node) => {
+  modals.add(new Modal(shallowRef(NodeDeleteModal), { props: { node: node, redirectTo: '/dashboard' }, size: 'small' }));
+};
+
 const resetKanban = () => {
   modals.add(
     new Modal(shallowRef(ResetBoardModal), {
@@ -199,6 +297,40 @@ h1 {
 
 .node-content {
   margin-top: 8px;
+}
+
+.bulk-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+}
+
+.action-btn {
+  cursor: pointer;
+  &:hover {
+    background: var(--surface-transparent);
+  }
+}
+
+.selected-count {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 32px;
+  height: 34px;
+  padding: 4px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xs);
+  font-size: 12px;
+  font-weight: bold;
+  color: var(--text-secondary);
+}
+
+.divider {
+  height: 32px;
+  margin-left: 4px;
+  border-left: 1px solid var(--border);
 }
 
 .line-container {

--- a/frontend/app/components/Node/ContainerView.vue
+++ b/frontend/app/components/Node/ContainerView.vue
@@ -58,38 +58,7 @@
     <!-- Content based on view mode -->
     <div v-if="filteredNodes.length" class="node-content">
       <!-- Advanced DataTable View -->
-      <div v-if="view === 'advanced'" class="line-container" style="padding-top: 10px;">
-        <DataTable ref="tableRef" :headers="headers" :rows="rows">
-          <template #bulk-actions="{ selected }">
-            <div class="bulk-actions">
-              <span class="selected-count">{{ selected.length }}</span>
-              <span class="divider" />
-              <AppSelect
-                v-model="bulkParentId"
-                :items="parentNodes"
-                :placeholder="t('common.placeholder.parent')"
-                size="240px"
-                @update:model-value="parentId => bulkSetParent(selected, parentId)"
-              />
-              <span class="divider" />
-              <span @click="bulkDelete(selected)"><Icon name="delete" fill="var(--text-secondary)" class="action-btn" /></span>
-            </div>
-          </template>
-          <template #name="{ cell }">
-            <div style="display:flex;align-items:center;gap:8px;">
-              <Icon :name="asNode(cell?.data)?.icon || 'files'" />
-              <NuxtLink :to="`/dashboard/docs/${asNode(cell?.data)?.id}`">{{ asNode(cell?.data)?.name }}</NuxtLink>
-            </div>
-          </template>
-          <template #tags="{ cell }">
-            <NodeTagList v-if="cell?.data" :tags="asNode(cell.data).tags" class="tags" />
-          </template>
-          <template #action="{ cell }">
-            <NuxtLink :to="`/dashboard/docs/${asNode(cell?.data)?.id}`"><Icon name="edit" style="margin-right: 10px" /></NuxtLink>
-            <span style="cursor: pointer" @click="() => deleteNode(asNode(cell?.data))"><Icon name="delete" /></span>
-          </template>
-        </DataTable>
-      </div>
+      <NodeAdvancedView v-if="view === 'advanced'" :nodes="filteredNodes" />
 
       <!-- Table/List View -->
       <div v-else-if="view === 'table'" class="line-container">
@@ -133,14 +102,10 @@ import RemoveSharedNode from '~/components/Node/Modals/RemoveShared.vue';
 import NodeMetadataModal from '~/components/Node/Modals/Metadata.vue';
 import KanbanBoard, { type KanbanMetadata } from '~/components/Kanban/Board.vue';
 import ResetBoardModal from '../Kanban/ResetBoard.modal.vue';
-import { assignParent } from '~/helpers/resources-parent';
 import type { ViewMode } from '~/components/ViewSelection.vue';
 import type { Node } from '~/stores';
-import type { Field } from '~/components/DataTable.vue';
 
 const props = defineProps<{ parent?: Node; nodes: Node[]; parentId?: string }>();
-
-const asNode = (data: unknown) => data as Node;
 
 const nodesStore = useNodesStore();
 const nodesPermissionsStore = useNodesPermissionsStore();
@@ -151,23 +116,9 @@ const { getAppAccent } = useAppColors();
 const { t } = useI18nT();
 const router = useRouter();
 const slots = useSlots();
-const { numericDate } = useDateFormatters();
-const notifications = useNotifications();
-const tree = useNodesTree();
-const parentNodes = tree.getTreeUpToRole(3);
 
 const connectedId = userStore.user?.id;
-const tableRef = ref<{ selectedRows: Field[] } | null>(null);
-const bulkParentId = ref<string | number>('');
 
-const headers = [
-  { key: 'name', label: t('common.labels.name') },
-  { key: 'type', label: t('common.labels.type') },
-  { key: 'parent', label: t('common.labels.parent') },
-  { key: 'tags', label: 'Tags' },
-  { key: 'date', label: t('common.labels.date') },
-  { key: 'action', label: t('common.labels.action') },
-];
 const view = ref<ViewMode>();
 const filteredNodes = ref<Node[]>(props.nodes);
 const kanbanBoard = ref<InstanceType<typeof KanbanBoard> | null>(null);
@@ -179,45 +130,7 @@ watch(
   { immediate: true },
 );
 
-const rows: ComputedRef<Field[]> = computed(() =>
-  filteredNodes.value.map(res => {
-    const parent = res.parent_id ? nodesStore.getById(res.parent_id) : null;
-    return {
-      action: { data: res, type: 'slot' },
-      date: { content: numericDate(res.updated_timestamp), type: 'text' },
-      name: { data: res, type: 'slot' },
-      parent: { content: parent ? `<tag class="${getAppAccent(parent.color as number, true)}">${parent.name}</tag>` : '', type: 'html' },
-      tags: { data: res.tags, type: 'slot' },
-      type: { content: `<tag class="primary">Document</tag>`, type: 'html' },
-    };
-  }),
-);
-
 // Actions
-const bulkDelete = async (lines: Field[]) => {
-  const nodes = lines.map(line => line.action?.data as Node);
-  modals.add(new Modal(shallowRef(NodeDeleteModal), { props: { nodes: nodes, redirectTo: '/dashboard' }, size: 'small' }));
-};
-
-const bulkSetParent = async (lines: Field[], parentId: string | number) => {
-  if (!parentId) return;
-  const nodesToUpdate = assignParent(
-    lines.map(line => line.action?.data as Node),
-    parentId as string,
-  );
-  try {
-    await Promise.all(nodesToUpdate.map(node => nodesStore.update(node)));
-    bulkParentId.value = '';
-    if (tableRef.value) tableRef.value.selectedRows = [];
-    notifications.add({ title: t('common.actions.update'), type: 'success' });
-  } catch (e) {
-    notifications.add({ message: String(e), title: 'Error', type: 'error' });
-  }
-};
-
-const deleteNode = (node: Node) => {
-  modals.add(new Modal(shallowRef(NodeDeleteModal), { props: { node: node, redirectTo: '/dashboard' }, size: 'small' }));
-};
 
 const resetKanban = () => {
   modals.add(
@@ -297,41 +210,6 @@ h1 {
 
 .node-content {
   margin-top: 8px;
-}
-
-.bulk-actions {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  width: 100%;
-}
-
-.action-btn {
-  cursor: pointer;
-
-  &:hover {
-    background: var(--surface-transparent);
-  }
-}
-
-.selected-count {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  width: 32px;
-  height: 34px;
-  padding: 4px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-xs);
-  font-size: 12px;
-  font-weight: bold;
-  color: var(--text-secondary);
-}
-
-.divider {
-  height: 32px;
-  margin-left: 4px;
-  border-left: 1px solid var(--border);
 }
 
 .line-container {

--- a/frontend/app/components/Node/ContainerView.vue
+++ b/frontend/app/components/Node/ContainerView.vue
@@ -140,7 +140,7 @@ import type { Field } from '~/components/DataTable.vue';
 
 const props = defineProps<{ parent?: Node; nodes: Node[]; parentId?: string }>();
 
-const asNode = (data: any) => data as Node;
+const asNode = (data: unknown) => data as Node;
 
 const nodesStore = useNodesStore();
 const nodesPermissionsStore = useNodesPermissionsStore();

--- a/frontend/app/components/Node/ContainerView.vue
+++ b/frontend/app/components/Node/ContainerView.vue
@@ -308,6 +308,7 @@ h1 {
 
 .action-btn {
   cursor: pointer;
+
   &:hover {
     background: var(--surface-transparent);
   }

--- a/frontend/app/components/ViewSelection.vue
+++ b/frontend/app/components/ViewSelection.vue
@@ -9,7 +9,7 @@
 
 <script setup lang="ts">
 import localForage from 'localforage';
-export type ViewMode = 'kanban' | 'list' | 'table';
+export type ViewMode = 'kanban' | 'list' | 'table' | 'advanced';
 
 const props = withDefaults(
   defineProps<{
@@ -25,8 +25,9 @@ const view = defineModel<ViewMode>();
 
 const viewOptions = computed(() => {
   const options = [
-    { icon: 'table', label: t('components.viewSelection.list'), value: 'list' as ViewMode },
+    { icon: 'grid', label: t('components.viewSelection.list'), value: 'list' as ViewMode },
     { icon: 'list', label: t('components.viewSelection.table'), value: 'table' as ViewMode },
+    { icon: 'table', label: 'Advanced', value: 'advanced' as ViewMode },
   ];
   if (props.showKanban) {
     options.push({ icon: 'kanban', label: t('components.viewSelection.kanban'), value: 'kanban' as ViewMode });
@@ -40,7 +41,7 @@ watch(view, newView => {
 
 onMounted(async () => {
   const storedView = await localForage.getItem<ViewMode>('viewSelection');
-  const list = ['table', 'list'];
+  const list = ['table', 'list', 'advanced'];
   if (props.showKanban) list.push('kanban');
   if (storedView && list.includes(storedView)) view.value = storedView as ViewMode;
   else view.value = 'table';

--- a/frontend/app/components/ViewSelection.vue
+++ b/frontend/app/components/ViewSelection.vue
@@ -21,14 +21,17 @@ const props = withDefaults(
 );
 
 const { t } = useI18nT();
+const preferences = usePreferencesStore();
 const view = defineModel<ViewMode>();
 
 const viewOptions = computed(() => {
   const options = [
-    { icon: 'grid', label: t('components.viewSelection.list'), value: 'list' as ViewMode },
+    { icon: 'table', label: t('components.viewSelection.list'), value: 'list' as ViewMode },
     { icon: 'list', label: t('components.viewSelection.table'), value: 'table' as ViewMode },
-    { icon: 'table', label: 'Advanced', value: 'advanced' as ViewMode },
   ];
+  if (preferences.get('advancedView').value) {
+    options.push({ icon: 'grid', label: 'Advanced', value: 'advanced' as ViewMode });
+  }
   if (props.showKanban) {
     options.push({ icon: 'kanban', label: t('components.viewSelection.kanban'), value: 'kanban' as ViewMode });
   }
@@ -41,7 +44,8 @@ watch(view, newView => {
 
 onMounted(async () => {
   const storedView = await localForage.getItem<ViewMode>('viewSelection');
-  const list = ['table', 'list', 'advanced'];
+  const list = ['table', 'list'];
+  if (preferences.get('advancedView').value) list.push('advanced');
   if (props.showKanban) list.push('kanban');
   if (storedView && list.includes(storedView)) view.value = storedView as ViewMode;
   else view.value = 'table';

--- a/frontend/app/composables/useDateFormatters.ts
+++ b/frontend/app/composables/useDateFormatters.ts
@@ -9,7 +9,10 @@ export const useDateFormatters = () => {
 
   /** Format a timestamp to a numeric date string (e.g., "12/15/2024") */
   function numericDate(timestamp?: number | string): string {
-    return new Date(timestamp || '').toLocaleDateString(locale.value, {
+    if (!timestamp) return '';
+    const date = new Date(timestamp);
+    if (isNaN(date.getTime())) return '';
+    return date.toLocaleDateString(locale.value, {
       year: 'numeric',
       month: '2-digit',
       day: '2-digit',

--- a/frontend/app/pages/dashboard/cdn/[id]/preview.vue
+++ b/frontend/app/pages/dashboard/cdn/[id]/preview.vue
@@ -53,17 +53,6 @@ const zoom = ref<(typeof PDF_SCALES)[number]['id']>('automatic_zoom');
 const resource = computed(() => nodesStore.getById(route.params.id as string));
 const mimeType = computed(() => resource.value?.metadata?.filetype || '');
 
-// Fetch the node if it's missing (e.g. on direct navigation or page refresh)
-useAsyncData(`cdn-preview-${route.params.id}`, async () => {
-  if (!resource.value) {
-    try {
-      await nodesStore.fetch({ id: route.params.id as string });
-    } catch (e) {
-      console.error('Failed to fetch resource for preview', e);
-    }
-  }
-});
-
 // Actions
 const copyLink = () => navigator.clipboard.writeText(resourceURL(resource.value!));
 

--- a/frontend/app/pages/dashboard/cdn/[id]/preview.vue
+++ b/frontend/app/pages/dashboard/cdn/[id]/preview.vue
@@ -53,6 +53,17 @@ const zoom = ref<(typeof PDF_SCALES)[number]['id']>('automatic_zoom');
 const resource = computed(() => nodesStore.getById(route.params.id as string));
 const mimeType = computed(() => resource.value?.metadata?.filetype || '');
 
+// Fetch the node if it's missing (e.g. on direct navigation or page refresh)
+useAsyncData(`cdn-preview-${route.params.id}`, async () => {
+  if (!resource.value) {
+    try {
+      await nodesStore.fetch({ id: route.params.id as string });
+    } catch (e) {
+      console.error('Failed to fetch resource for preview', e);
+    }
+  }
+});
+
 // Actions
 const copyLink = () => navigator.clipboard.writeText(resourceURL(resource.value!));
 

--- a/frontend/app/pages/dashboard/settings/_views/other.vue
+++ b/frontend/app/pages/dashboard/settings/_views/other.vue
@@ -32,6 +32,13 @@ const options = computed<Array<{ label: string; options: InterfaceOption[] }>>((
           { label: '250', id: 250 },
         ],
       },
+      {
+        label: 'Enable Advanced View',
+        description: 'Enable the advanced datatable view with bulk actions for Categories and Workspaces.',
+        type: 'toggle',
+        key: 'advancedView',
+        tag: t('settings.nav.new'),
+      },
     ],
   },
   {

--- a/frontend/app/stores/preferences/constants.ts
+++ b/frontend/app/stores/preferences/constants.ts
@@ -15,6 +15,7 @@ export const DEFAULT_PREFERENCES = {
   displayFeatureTags: true as boolean,
   displayUncategorizedResources: true as boolean,
   displayTabs: false as boolean,
+  advancedView: false as boolean,
   datatableItemsCount: 10 as number,
   view_dock: true as boolean,
   primaryColor: -2 as number, // -2 default primary; -1 unset; >= 0 app color index
@@ -100,6 +101,7 @@ export const GENERAL_KEYS: PreferenceKey[] = [
   'displayFeatureTags',
   'displayUncategorizedResources',
   'displayTabs',
+  'advancedView',
   'datatableItemsCount',
   'view_dock',
   'primaryColor',


### PR DESCRIPTION
- Implemented Bulk Move (assign parent) and Bulk Delete actions for the Advanced View in Categories/Workspaces, mirroring the CDN view's functionality.
- Fixed a silent rendering crash caused by `numericDate` failing on undefined timestamps.
- Resolved template compilation hazards by replacing `$any` casting with native TypeScript helpers.
- Updated `DataTable` "Select All" checkbox to remove the indeterminate state for a strictly binary toggle.
- Corrected missing view selection icons by mapping to valid sprite assets.
- Resolved a hydration issue on the CDN preview page during hard refreshes.

Closes #679