### PR TITLE
fix(tags): show suggestions on focus

### DIFF
--- a/frontend/app/components/AppTagInput.vue
+++ b/frontend/app/components/AppTagInput.vue
@@ -80,7 +80,7 @@ function stringToTags(str: string): string[] {
 }
 
 const filteredTagSuggestions = computed(() => {
-  if (!tagInput.value) return [];
+  if (!tagInput.value) return nodesStore.allTags;
   const input = tagInput.value.toLowerCase();
   return nodesStore.allTags.filter(tag => tag.toLowerCase().includes(input) && !tagInput.value.includes(tag)).slice(0, 5);
 });


### PR DESCRIPTION
## Summary

- show all existing tags as soon as the tag input receives focus
- preserve the current filtered, five-result suggestion list while typing

Closes #709

## Validation

- `bun run lint`
- `bun run lint:css`
- `bun run typecheck`
- `bun run build`