### PR TITLE
fix(editor): validate document titles before saving

### DIFF
--- a/frontend/app/components/MarkdownEditor/MarkdownEditor.vue
+++ b/frontend/app/components/MarkdownEditor/MarkdownEditor.vue
@@ -11,7 +11,15 @@
       <!-- Compact Document Metadata -->
       <div class="document-meta">
         <div class="line">
-          <input v-model="document.name" :placeholder="t('components.editor.placeholder.title')" class="meta-title" @input="autoSaveConditional" />
+          <input
+            ref="titleInput"
+            v-model="document.name"
+            :autofocus="autofocusTitle"
+            :placeholder="t('components.editor.placeholder.title')"
+            class="meta-title"
+            required
+            @input="autoSaveConditional"
+          />
           <input
             v-model="document.description"
             :placeholder="t('components.editor.placeholder.description')"
@@ -62,13 +70,14 @@ const resourcesStore = useResourcesStore();
 const nodesStore = useNodesStore();
 const preferences = usePreferencesStore();
 
-defineProps<{ public?: boolean }>();
+const props = defineProps<{ public?: boolean; autofocusTitle?: boolean }>();
 const emit = defineEmits<{
   (e: 'save' | 'autoSave', doc: Partial<Node>): void;
   (e: 'exit'): void;
 }>();
 
 const editorContainer = ref<HTMLDivElement>();
+const titleInput = ref<HTMLInputElement>();
 const markdownPreviewComponent = ref<InstanceType<typeof NodeDocumentContentCompiled>>();
 const markdownPreview = computed(() => markdownPreviewComponent.value?.rootElement as HTMLElement | undefined);
 const editorView = ref<EditorView | null>(null);
@@ -127,6 +136,7 @@ const state = createEditorState({
 });
 
 onMounted(() => {
+  if (props.autofocusTitle) titleInput.value?.focus();
   if (!editorContainer.value) return;
   editorView.value = new EditorView({
     state,
@@ -185,11 +195,19 @@ const updateDocumentContent = debounce(() => {
 }, 100);
 
 const save = debounce(() => {
+  if (!document.value.name?.trim()) {
+    titleInput.value?.focus();
+    titleInput.value?.reportValidity();
+    return;
+  }
   updateDocumentContent();
   emit('save', document.value);
 }, 1000);
 
 const autoSave = debounceDelayed(() => {
+  // New documents persist locally before they have a title; existing documents
+  // must never overwrite their saved title with an empty value.
+  if (document.value.id && !document.value.name?.trim()) return;
   updateDocumentContent();
   emit('autoSave', document.value);
 }, 2000);

--- a/frontend/app/pages/dashboard/docs/new.vue
+++ b/frontend/app/pages/dashboard/docs/new.vue
@@ -1,5 +1,5 @@
 <template>
-  <LazyMarkdownEditor v-model="document" @save="data => save(data)" @exit="exit" @auto-save="savePending" />
+  <LazyMarkdownEditor v-model="document" autofocus-title @save="data => save(data)" @exit="exit" @auto-save="savePending" />
 </template>
 <script lang="ts" setup>
 import localForage from 'localforage';


### PR DESCRIPTION
## Summary

- focus the title field when opening a new document
- use native required-field validation before manual saves
- prevent existing documents from auto-saving an empty title while retaining local untitled drafts for new documents

Closes #707

## Validation

- `npm run lint`
- `npm run lint:css`
- `npm run typecheck`
- `npm run build`
- Playwright launched Microsoft Edge and verified initial focus, blocked blank-title saves, one valid save, and no second save after clearing the title
- `git diff --check`