### PR TITLE
fix: use parent_id query param for new kanban documents

### DIFF
--- a/frontend/app/components/Node/ContainerView.vue
+++ b/frontend/app/components/Node/ContainerView.vue
@@ -177,7 +177,7 @@ function createDocumentInColumn(columnId: string) {
   router.push({
     path: '/dashboard/docs/new',
     query: {
-      parent: String(props.parent.id),
+      parent_id: String(props.parent.id),
       kanbanColumn: columnId,
     },
   });


### PR DESCRIPTION
## Description

This PR resolves #720.

When clicking the `+` button in a Kanban column, the router was passing `parent` instead of `parent_id` in the query parameters. Because of this, the category wasn't being automatically selected on the `/new` page. 

I updated the query parameter in `ContainerView.vue` to `parent_id`, and the category now autofills correctly! I have attached "Before" and "After" screenshots below.

Let me know if this fully resolves the issue you were seeing!