### PR TITLE
Closes #617: Markdown add counters feature for automatic figures / tables / title labels

### DIFF
--- a/frontend/app/helpers/markdown/counters.test.ts
+++ b/frontend/app/helpers/markdown/counters.test.ts
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+import MarkdownIt from 'markdown-it';
+import { counterPlugin } from './counters';
+
+const md = new MarkdownIt();
+md.use(counterPlugin);
+
+function renderInline(str: string): string {
+  return md.renderInline(str);
+}
+
+describe('markdown counters', () => {
+  test('increments counters by label', () => {
+    assert.equal(renderInline('{{ figure }} {{ figure }} {{ table }}'), '1 2 1');
+  });
+
+  test('formats counters as roman numerals and letters', () => {
+    assert.equal(renderInline('{{ titleH1(R) }} {{ titleH1(R) }} {{ titleH2(l) }} {{ titleH2(L) }}'), 'I II a B');
+  });
+
+  test('does not replace counters inside code', () => {
+    assert.equal(renderInline('`{{ figure }}`'), '<code>{{ figure }}</code>');
+  });
+});

--- a/frontend/app/helpers/markdown/counters.ts
+++ b/frontend/app/helpers/markdown/counters.ts
@@ -1,0 +1,85 @@
+import type { MarkdownIt, StateInline } from 'markdown-it';
+
+type CounterStyle = '1' | 'L' | 'R' | 'l' | 'r';
+
+interface CounterEnv {
+  counterLabels?: Record<string, number>;
+}
+
+const COUNTER_REGEX = /^\{\{\s*([A-Za-z][A-Za-z0-9_-]*)(?:\(([1LRlr])\))?\s*\}\}/;
+
+function formatAlpha(value: number, uppercase: boolean): string {
+  let result = '';
+  let current = value;
+
+  while (current > 0) {
+    current--;
+    result = String.fromCharCode((current % 26) + (uppercase ? 65 : 97)) + result;
+    current = Math.floor(current / 26);
+  }
+
+  return result;
+}
+
+function formatRoman(value: number): string {
+  const numerals: [number, string][] = [
+    [1000, 'M'],
+    [900, 'CM'],
+    [500, 'D'],
+    [400, 'CD'],
+    [100, 'C'],
+    [90, 'XC'],
+    [50, 'L'],
+    [40, 'XL'],
+    [10, 'X'],
+    [9, 'IX'],
+    [5, 'V'],
+    [4, 'IV'],
+    [1, 'I'],
+  ];
+  let current = value;
+  let result = '';
+
+  for (const [amount, numeral] of numerals) {
+    while (current >= amount) {
+      result += numeral;
+      current -= amount;
+    }
+  }
+
+  return result;
+}
+
+function formatCounter(value: number, style: CounterStyle): string {
+  if (style === 'L') return formatAlpha(value, true);
+  if (style === 'l') return formatAlpha(value, false);
+  if (style === 'R') return formatRoman(value);
+  if (style === 'r') return formatRoman(value).toLowerCase();
+  return String(value);
+}
+
+export function counterPlugin(md: MarkdownIt) {
+  md.inline.ruler.before('emphasis', 'counter', (state: StateInline, silent: boolean) => {
+    const start = state.pos;
+    if (state.src.charCodeAt(start) !== 0x7b /* { */ || state.src.charCodeAt(start + 1) !== 0x7b) return false;
+
+    const match = state.src.slice(start, state.posMax).match(COUNTER_REGEX);
+    if (!match) return false;
+
+    if (!silent) {
+      const label = match[1]!;
+      const style = (match[2] ?? '1') as CounterStyle;
+      const env = state.env as CounterEnv;
+      env.counterLabels ??= {};
+      env.counterLabels[label] = (env.counterLabels[label] ?? 0) + 1;
+
+      const token = state.push('counter', '', 0);
+      token.content = formatCounter(env.counterLabels[label], style);
+    }
+
+    state.pos = start + match[0].length;
+    return true;
+  });
+
+  md.renderer.rules.counter = (tokens, idx) => md.utils.escapeHtml(tokens[idx]?.content ?? '');
+}

--- a/frontend/app/helpers/markdown/index.ts
+++ b/frontend/app/helpers/markdown/index.ts
@@ -16,6 +16,7 @@ import { markdownItKatexPlugin } from './katex';
 import { sourceMapPlugin } from './source-map';
 import { internalLinkPlugin } from './internal-links';
 import { tooltipPlugin } from './tooltip';
+import { counterPlugin } from './counters';
 import { full as emojiPlugin } from 'markdown-it-emoji';
 
 const md = new MarkdownIt({ html: true, linkify: true });
@@ -38,6 +39,7 @@ md.use(colorPlugin, {
   allowHex: true, // allow #rgb and #rrggbb
 });
 md.use(tooltipPlugin);
+md.use(counterPlugin);
 md.use(emojiPlugin);
 md.use(html5MediaPlugin);
 md.use(svgObjectPlugin);


### PR DESCRIPTION
Closes #617.

Verified against the pinned tree: the patch applies cleanly and the repository's own build passes with it.
This repository ships no test suite, so **no test exercised this change**. Please treat CI as the first real check.

Written by an AI coding agent (Sloppy) and opened under my account.

<!-- sloppy-mission-proof:slp_p_m_tmEov2fIb4O_Kf1DRODw -->