### PR TITLE
feat(editor): import pasted rich content and its images

### DIFF
--- a/frontend/app/components/MarkdownEditor/MarkdownEditor.vue
+++ b/frontend/app/components/MarkdownEditor/MarkdownEditor.vue
@@ -66,7 +66,6 @@ import NodeDocumentContentCompiled from '~/components/Node/Document/ContentCompi
 import type { Node } from '~/stores';
 
 const { t } = useI18nT();
-const resourcesStore = useResourcesStore();
 const nodesStore = useNodesStore();
 const preferences = usePreferencesStore();
 
@@ -104,7 +103,6 @@ const commands = createCommands({
 });
 
 const uploadsHandlers = createUploadsHandlers({
-  resourcesStore,
   nodeId: document.value.id,
   insertText: (t: string) => commands.exec('insertText', t),
 });

--- a/frontend/app/components/MarkdownEditor/modules/editorUploads.ts
+++ b/frontend/app/components/MarkdownEditor/modules/editorUploads.ts
@@ -1,46 +1,49 @@
 import { EditorView } from '@codemirror/view';
-import type { Node } from '~/stores';
+import { parseClipboard } from '~/helpers/clipboard/parse';
 
 interface UploadHandlersParams {
-  resourcesStore: ReturnType<typeof import('~/stores').useResourcesStore>;
   nodeId?: string;
   insertText: (text: string) => void;
 }
 
-export function createUploadsHandlers({ resourcesStore, nodeId, insertText }: UploadHandlersParams) {
-  const { resourceURL } = useApi();
+/**
+ * Paste and drop both hand the editor the same kind of payload, so both go through
+ * the clipboard import module: files and remote images are stored as resources, and
+ * the markdown that references them is inserted at the cursor.
+ */
+export function createUploadsHandlers({ nodeId, insertText }: UploadHandlersParams) {
+  const { importFrom } = useClipboardImport(nodeId);
+  const { add } = useNotifications();
+  const { t } = useI18nT();
+
+  async function handle(data: DataTransfer | null, event: Event) {
+    const { kind } = parseClipboard(data);
+
+    // Plain text is left to CodeMirror: it already handles selections, indentation
+    // and undo grouping better than re-inserting the text ourselves.
+    if (kind === 'empty' || kind === 'plain') return;
+
+    event.preventDefault();
+
+    const result = await importFrom(data);
+    if (result.markdown) insertText(`${result.markdown}\n`);
+
+    if (result.failed || result.skipped) {
+      add({
+        title: t('components.editor.clipboard.partialImportTitle'),
+        message: t('components.editor.clipboard.partialImport', { uploaded: result.uploaded, remaining: result.failed + result.skipped }),
+        type: 'warning',
+        timeout: 6000,
+      });
+    }
+  }
+
   return EditorView.domEventHandlers({
-    paste: event => {
-      const items = event.clipboardData?.items;
-      if (!items) return;
-      for (const item of items) {
-        if (item.kind === 'file') {
-          const file = item.getAsFile();
-          if (!file) return;
-          const body = new FormData();
-          body.append('parent_id', nodeId || '');
-          body.append('file', file);
-          resourcesStore.post(body).then((result: Node) => {
-            insertText(`![${file.name}](${resourceURL(result)})\n`);
-          });
-        }
-      }
+    paste: (event, _view) => {
+      handle(event.clipboardData, event);
     },
-    drop: event => {
-      const items = event.dataTransfer?.items;
-      if (!items) return;
-      for (const item of items) {
-        if (item.kind === 'file') {
-          const file = item.getAsFile();
-          if (!file) return;
-          const body = new FormData();
-          body.append('parent_id', nodeId || '');
-          body.append('file', file);
-          resourcesStore.post(body).then((result: Node) => {
-            insertText(`![${file.name}](${resourceURL(result)})\n`);
-          });
-        }
-      }
+    drop: (event, _view) => {
+      handle(event.dataTransfer, event);
     },
   });
 }

--- a/frontend/app/composables/useClipboardImport.ts
+++ b/frontend/app/composables/useClipboardImport.ts
@@ -1,0 +1,56 @@
+import { htmlToMarkdown } from '~/helpers/clipboard/html-to-markdown';
+import { importClipboard, type ImportResult } from '~/helpers/clipboard/import';
+import { parseClipboard } from '~/helpers/clipboard/parse';
+
+/** Remote images per paste. A copied article can carry dozens of thumbnails. */
+const MAX_REMOTE_IMAGES = 20;
+
+/**
+ * Remote images are fetched in the browser, so a source that does not send CORS
+ * headers cannot be stored locally. Aborting a slow one keeps a paste responsive;
+ * the image then stays referenced by its original URL.
+ */
+const FETCH_TIMEOUT_MS = 15_000;
+
+function fileNameFromUrl(url: string, type: string): string {
+  const fromPath = decodeURIComponent(new URL(url).pathname.split('/').pop() || '');
+  if (fromPath && /\.[a-z0-9]{2,5}$/i.test(fromPath)) return fromPath;
+
+  const extension = type.split('/')[1]?.replace(/[^a-z0-9]/gi, '') || 'png';
+  return `pasted-image.${extension}`;
+}
+
+/**
+ * Accepts whatever a paste or drop carries, stores its files and remote images as
+ * resources, and hands back markdown that references the stored copies.
+ */
+export function useClipboardImport(nodeId?: string) {
+  const resourcesStore = useResourcesStore();
+  const { resourceURL } = useApi();
+
+  async function upload(file: File): Promise<string> {
+    const body = new FormData();
+    if (nodeId) body.append('parent_id', nodeId);
+    body.append('file', file);
+
+    // The backend enforces the size and mime-type limits from its own config, so a
+    // rejected upload surfaces here as a failure rather than being pre-empted.
+    return resourceURL(await resourcesStore.post(body));
+  }
+
+  async function fetchImage(url: string): Promise<File> {
+    const response = await fetch(url, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS), credentials: 'omit', referrerPolicy: 'no-referrer' });
+    if (!response.ok) throw new Error(`Request failed with ${response.status}`);
+
+    const blob = await response.blob();
+    if (!blob.type.startsWith('image/')) throw new Error('The response was not an image.');
+
+    return new File([blob], fileNameFromUrl(url, blob.type), { type: blob.type });
+  }
+
+  async function importFrom(data: DataTransfer | null): Promise<ImportResult> {
+    return importClipboard(parseClipboard(data), { upload, fetchImage, htmlToMarkdown, maxImages: MAX_REMOTE_IMAGES });
+  }
+
+  return { importFrom };
+}

--- a/frontend/app/helpers/clipboard/html-to-markdown.test.ts
+++ b/frontend/app/helpers/clipboard/html-to-markdown.test.ts
@@ -1,0 +1,89 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+import { htmlToMarkdown } from './html-to-markdown';
+
+describe('htmlToMarkdown', () => {
+  test('converts headings, emphasis and links', () => {
+    const md = htmlToMarkdown('<h2>Title</h2><p>Some <strong>bold</strong> and <em>italic</em> and a <a href="https://example.com">link</a>.</p>');
+
+    assert.match(md, /^## Title/m);
+    assert.match(md, /\*\*bold\*\*/);
+    assert.match(md, /\*italic\*/);
+    assert.match(md, /\[link\]\(https:\/\/example\.com\)/);
+  });
+
+  test('converts nested lists', () => {
+    const md = htmlToMarkdown('<ul><li>one<ul><li>nested</li></ul></li><li>two</li></ul>');
+
+    // turndown pads the marker; both `- x` and `-   x` are valid markdown.
+    assert.match(md, /^-\s+one/m);
+    assert.match(md, /^\s+-\s+nested/m);
+    assert.match(md, /^-\s+two/m);
+  });
+
+  test('emits a single delimiter row for a table', () => {
+    const html = '<table><tr><th>A</th><th>B</th></tr><tr><td>1</td><td>2</td></tr><tr><td>3</td><td>4</td></tr></table>';
+
+    const md = htmlToMarkdown(html);
+    const delimiters = md.split('\n').filter(line => /^\|(\s*---\s*\|)+$/.test(line.trim()));
+
+    assert.equal(delimiters.length, 1, `expected exactly one delimiter row, got:\n${md}`);
+  });
+
+  test('does not scatter delimiter rows through a layout table that has a th on every row', () => {
+    // Shape of a Wikipedia infobox: a header cell per row, not a header row.
+    const html = '<table><tr><th>Family</th><td>Modeling</td></tr><tr><th>Website</th><td>uml.org</td></tr><tr><th>Year</th><td>1997</td></tr></table>';
+
+    const md = htmlToMarkdown(html);
+    const delimiters = md.split('\n').filter(line => /^\|(\s*---\s*\|)+$/.test(line.trim()));
+
+    assert.equal(delimiters.length, 1, `a delimiter after every row is invalid markdown, got:\n${md}`);
+    assert.match(md, /Family/);
+    assert.match(md, /Website/);
+    assert.match(md, /1997/);
+  });
+
+  test('keeps image sources so they can be rewritten after upload', () => {
+    const md = htmlToMarkdown('<p><img src="https://example.com/a.png" alt="Alt text"></p>');
+
+    assert.match(md, /!\[Alt text\]\(https:\/\/example\.com\/a\.png\)/);
+  });
+
+  test('puts a figure caption below the image rather than inside its alt text', () => {
+    const md = htmlToMarkdown('<figure><img src="https://example.com/a.png"><figcaption>A caption</figcaption></figure>');
+
+    assert.match(md, /!\[A caption\]\(https:\/\/example\.com\/a\.png\)/);
+    assert.match(md, /\*A caption\*/);
+  });
+
+  test('drops style and script content that browsers copy along', () => {
+    const md = htmlToMarkdown('<style>.a{color:red}</style><p>text</p><script>alert(1)</script>');
+
+    assert.equal(md, 'text');
+  });
+
+  test('strips the inline styles and wrappers that clipboard html carries', () => {
+    const html = '<section style="color: rgb(32,33,34); font-family: sans-serif"><span style="font-weight:400"><p>Just text</p></span></section>';
+
+    assert.equal(htmlToMarkdown(html), 'Just text');
+  });
+
+  test('collapses runs of blank lines', () => {
+    const md = htmlToMarkdown('<p>one</p><div></div><div></div><p>two</p>');
+
+    assert.doesNotMatch(md, /\n{3,}/);
+  });
+
+  test('converts code and preformatted blocks', () => {
+    const md = htmlToMarkdown('<p>use <code>npm</code></p><pre><code>line one\nline two</code></pre>');
+
+    assert.match(md, /`npm`/);
+    assert.match(md, /```/);
+    assert.match(md, /line one/);
+  });
+
+  test('returns an empty string for empty input', () => {
+    assert.equal(htmlToMarkdown(''), '');
+  });
+});

--- a/frontend/app/helpers/clipboard/html-to-markdown.ts
+++ b/frontend/app/helpers/clipboard/html-to-markdown.ts
@@ -1,0 +1,71 @@
+import TurndownService from 'turndown';
+
+/**
+ * Clipboard HTML is verbose: browsers copy inline styles, wrapper sections and
+ * tracking attributes alongside the content. Turndown handles the structure, and the
+ * rules below drop what would otherwise survive as noise.
+ */
+let service: TurndownService | null = null;
+
+function createService(): TurndownService {
+  const turndown = new TurndownService({
+    headingStyle: 'atx',
+    hr: '---',
+    bulletListMarker: '-',
+    codeBlockStyle: 'fenced',
+    emDelimiter: '*',
+  });
+
+  // Neither carries meaning once the content is markdown, and both bring long
+  // attribute payloads with them.
+  turndown.remove(['style', 'script', 'noscript']);
+
+  // Keep tables: turndown emits them as HTML by default, but the markdown pipeline
+  // renders GFM tables, so a simple conversion reads better in the editor.
+  turndown.addRule('tableCell', {
+    filter: ['th', 'td'],
+    replacement: content => ` ${content.trim().replace(/\n+/g, ' ')} |`,
+  });
+  turndown.addRule('tableRow', {
+    filter: 'tr',
+    replacement: (content, node) => {
+      const row = node as HTMLTableRowElement;
+      // Markdown allows exactly one delimiter row, right after the first one. Layout
+      // tables (an infobox, say) put a <th> label on every row, so keying off <th>
+      // per row would scatter delimiters through the table and break it.
+      const rows = row.closest('table')?.querySelectorAll('tr');
+      const isFirstRow = !rows || rows.length === 0 || rows.item(0) === row;
+      const separator = isFirstRow ? `\n|${' --- |'.repeat(row.cells.length)}` : '';
+      return `\n|${content}${separator}`;
+    },
+  });
+  turndown.addRule('table', {
+    filter: 'table',
+    replacement: content => `\n${content.trim()}\n`,
+  });
+
+  // A figure's caption belongs under the image, not inside its alt text.
+  turndown.addRule('figure', {
+    filter: 'figure',
+    replacement: (_content, node) => {
+      const img = (node as HTMLElement).querySelector('img');
+      const caption = (node as HTMLElement).querySelector('figcaption')?.textContent?.trim();
+      if (!img) return caption ? `\n${caption}\n` : '';
+
+      const src = img.getAttribute('src') ?? '';
+      const alt = img.getAttribute('alt')?.trim() || caption || '';
+      return `\n![${alt}](${src})\n${caption ? `\n*${caption}*\n` : ''}`;
+    },
+  });
+
+  return turndown;
+}
+
+export function htmlToMarkdown(html: string): string {
+  service ??= createService();
+
+  return service
+    .turndown(html)
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}

--- a/frontend/app/helpers/clipboard/import.test.ts
+++ b/frontend/app/helpers/clipboard/import.test.ts
@@ -1,0 +1,164 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+import { importClipboard, type ImportContext } from './import';
+
+/** Context whose uploader records calls and returns a predictable CDN URL. */
+function stubContext(overrides: Partial<ImportContext> = {}): ImportContext & { uploads: string[] } {
+  const uploads: string[] = [];
+
+  const ctx = {
+    uploads,
+    maxImages: 20,
+    upload: async (file: File) => {
+      uploads.push(file.name);
+      return `https://cdn.test/${file.name}`;
+    },
+    fetchImage: async (url: string) => new File([new Uint8Array([1, 2, 3])], url.split('/').pop() || 'image.png', { type: 'image/png' }),
+    htmlToMarkdown: (html: string) => html.replace(/<[^>]+>/g, '').trim(),
+    ...overrides,
+  } as ImportContext & { uploads: string[] };
+
+  return ctx;
+}
+
+describe('importClipboard', () => {
+  test('uploads pasted files and references them as markdown images', async () => {
+    const ctx = stubContext();
+    const file = new File([new Uint8Array([1])], 'shot.png', { type: 'image/png' });
+
+    const result = await importClipboard({ kind: 'files', files: [file], remoteImages: [] }, ctx);
+
+    assert.deepEqual(ctx.uploads, ['shot.png']);
+    assert.equal(result.markdown, '![shot.png](https://cdn.test/shot.png)');
+    assert.equal(result.uploaded, 1);
+    assert.equal(result.failed, 0);
+  });
+
+  test('links non-image files instead of embedding them', async () => {
+    const ctx = stubContext();
+    const file = new File([new Uint8Array([1])], 'notes.pdf', { type: 'application/pdf' });
+
+    const result = await importClipboard({ kind: 'files', files: [file], remoteImages: [] }, ctx);
+
+    assert.equal(result.markdown, '[notes.pdf](https://cdn.test/notes.pdf)');
+  });
+
+  test('converts rich html and rewrites its image urls to the uploaded copies', async () => {
+    const ctx = stubContext({
+      htmlToMarkdown: () => '# Title\n\n![](https://example.com/a.png)\n\ntext',
+    });
+
+    const result = await importClipboard(
+      { kind: 'rich', files: [], html: '<h1>Title</h1><img src="https://example.com/a.png">', remoteImages: ['https://example.com/a.png'] },
+      ctx,
+    );
+
+    assert.equal(result.markdown, '# Title\n\n![](https://cdn.test/a.png)\n\ntext');
+    assert.equal(result.uploaded, 1);
+    assert.equal(result.failed, 0);
+  });
+
+  test('keeps the original url when the image cannot be fetched', async () => {
+    const ctx = stubContext({
+      fetchImage: async () => {
+        throw new Error('CORS');
+      },
+      htmlToMarkdown: () => '![](https://example.com/a.png)',
+    });
+
+    const result = await importClipboard({ kind: 'rich', files: [], html: '<img src="https://example.com/a.png">', remoteImages: ['https://example.com/a.png'] }, ctx);
+
+    assert.equal(result.markdown, '![](https://example.com/a.png)', 'the image must stay reachable via its origin');
+    assert.equal(result.uploaded, 0);
+    assert.equal(result.failed, 1);
+  });
+
+  test('reports partial success so the caller can tell the user', async () => {
+    let call = 0;
+    const ctx = stubContext({
+      fetchImage: async (url: string) => {
+        if (++call === 2) throw new Error('CORS');
+        return new File([new Uint8Array([1])], url.split('/').pop()!, { type: 'image/png' });
+      },
+      htmlToMarkdown: () => '![](https://e.com/a.png) ![](https://e.com/b.png) ![](https://e.com/c.png)',
+    });
+
+    const result = await importClipboard(
+      { kind: 'rich', files: [], html: 'x', remoteImages: ['https://e.com/a.png', 'https://e.com/b.png', 'https://e.com/c.png'] },
+      ctx,
+    );
+
+    assert.equal(result.uploaded, 2);
+    assert.equal(result.failed, 1);
+    assert.match(result.markdown, /cdn\.test\/a\.png/);
+    assert.match(result.markdown, /e\.com\/b\.png/, 'the failed one keeps its original url');
+    assert.match(result.markdown, /cdn\.test\/c\.png/);
+  });
+
+  test('rewrites every occurrence of a repeated image', async () => {
+    const ctx = stubContext({
+      htmlToMarkdown: () => '![](https://e.com/a.png)\n![](https://e.com/a.png)',
+    });
+
+    const result = await importClipboard({ kind: 'rich', files: [], html: 'x', remoteImages: ['https://e.com/a.png'] }, ctx);
+
+    assert.equal(result.markdown, '![](https://cdn.test/a.png)\n![](https://cdn.test/a.png)');
+    assert.equal(ctx.uploads.length, 1, 'one upload serves both references');
+  });
+
+  test('stops after maxImages, so pasting a whole article cannot flood the CDN', async () => {
+    const many = Array.from({ length: 8 }, (_, i) => `https://e.com/${i}.png`);
+    const ctx = stubContext({ maxImages: 3, htmlToMarkdown: () => many.map(u => `![](${u})`).join('\n') });
+
+    const result = await importClipboard({ kind: 'rich', files: [], html: 'x', remoteImages: many }, ctx);
+
+    assert.equal(ctx.uploads.length, 3);
+    assert.equal(result.uploaded, 3);
+    assert.equal(result.skipped, 5);
+    assert.match(result.markdown, /e\.com\/7\.png/, 'skipped images keep their original url');
+  });
+
+  test('passes plain text through untouched', async () => {
+    const ctx = stubContext();
+
+    const result = await importClipboard({ kind: 'plain', files: [], text: 'just text', remoteImages: [] }, ctx);
+
+    assert.equal(result.markdown, 'just text');
+    assert.deepEqual(ctx.uploads, []);
+  });
+
+  test('prefers plain text when the html carries no formatting worth keeping', async () => {
+    const ctx = stubContext({ htmlToMarkdown: () => 'hello' });
+
+    const result = await importClipboard({ kind: 'rich', files: [], html: '<span>hello</span>', text: 'hello', remoteImages: [] }, ctx);
+
+    assert.equal(result.markdown, 'hello');
+  });
+
+  test('returns nothing for an empty payload', async () => {
+    const ctx = stubContext();
+
+    const result = await importClipboard({ kind: 'empty', files: [], remoteImages: [] }, ctx);
+
+    assert.equal(result.markdown, '');
+    assert.equal(result.uploaded, 0);
+  });
+
+  test('a failing upload does not abort the remaining ones', async () => {
+    let call = 0;
+    const ctx = stubContext({
+      upload: async (file: File) => {
+        if (++call === 1) throw new Error('upload rejected');
+        return `https://cdn.test/${file.name}`;
+      },
+    });
+    const files = [new File([new Uint8Array([1])], 'a.png', { type: 'image/png' }), new File([new Uint8Array([1])], 'b.png', { type: 'image/png' })];
+
+    const result = await importClipboard({ kind: 'files', files, remoteImages: [] }, ctx);
+
+    assert.equal(result.uploaded, 1);
+    assert.equal(result.failed, 1);
+    assert.match(result.markdown, /cdn\.test\/b\.png/);
+  });
+});

--- a/frontend/app/helpers/clipboard/import.ts
+++ b/frontend/app/helpers/clipboard/import.ts
@@ -1,0 +1,93 @@
+import type { ClipboardPayload } from './parse';
+
+/**
+ * Clipboard import: turn an analysed payload into markdown, storing any file or
+ * remote image as a resource on the way. Every side effect is injected, which keeps
+ * this testable without a network or a store.
+ */
+export interface ImportContext {
+  /** Store a file and return the URL to reference it by. */
+  upload: (file: File) => Promise<string>;
+  /** Fetch a remote image so it can be stored locally. Rejects when blocked. */
+  fetchImage: (url: string) => Promise<File>;
+  htmlToMarkdown: (html: string) => string;
+  /** Upper bound on remote images per paste, so one paste cannot flood the store. */
+  maxImages: number;
+}
+
+export interface ImportResult {
+  markdown: string;
+  uploaded: number;
+  failed: number;
+  skipped: number;
+}
+
+function reference(name: string, url: string, isImage: boolean): string {
+  return isImage ? `![${name}](${url})` : `[${name}](${url})`;
+}
+
+/** Replace every occurrence of a URL inside markdown, matching it literally. */
+function replaceAll(markdown: string, from: string, to: string): string {
+  return markdown.split(from).join(to);
+}
+
+export async function importClipboard(payload: ClipboardPayload, ctx: ImportContext): Promise<ImportResult> {
+  let uploaded = 0;
+  let failed = 0;
+  let skipped = 0;
+
+  if (payload.kind === 'empty') {
+    return { markdown: '', uploaded, failed, skipped };
+  }
+
+  // Files arrive already local: store each and reference it. Uploads run one at a
+  // time so a large paste cannot open a dozen parallel requests.
+  if (payload.kind === 'files') {
+    const parts: string[] = [];
+
+    for (const file of payload.files) {
+      try {
+        const url = await ctx.upload(file);
+        parts.push(reference(file.name, url, file.type.startsWith('image/')));
+        uploaded++;
+      } catch {
+        // Keep going: one rejected upload should not lose the rest of the paste.
+        failed++;
+      }
+    }
+
+    return { markdown: parts.join('\n'), uploaded, failed, skipped };
+  }
+
+  if (payload.kind === 'plain') {
+    return { markdown: payload.text ?? '', uploaded, failed, skipped };
+  }
+
+  let markdown = ctx.htmlToMarkdown(payload.html ?? '').trim();
+
+  // Some sources wrap plain text in markup that converts to the same text; the
+  // plain flavour is then the more faithful paste.
+  if (payload.text && markdown === payload.text.trim()) {
+    markdown = payload.text;
+  }
+
+  for (const [index, url] of payload.remoteImages.entries()) {
+    if (index >= ctx.maxImages) {
+      // Leave the rest pointing at their origin rather than silently dropping them.
+      skipped++;
+      continue;
+    }
+
+    try {
+      const file = await ctx.fetchImage(url);
+      markdown = replaceAll(markdown, url, await ctx.upload(file));
+      uploaded++;
+    } catch {
+      // A blocked fetch (CORS) or a rejected upload leaves the original URL in
+      // place, so the image still renders from its source.
+      failed++;
+    }
+  }
+
+  return { markdown, uploaded, failed, skipped };
+}

--- a/frontend/app/helpers/clipboard/parse.test.ts
+++ b/frontend/app/helpers/clipboard/parse.test.ts
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+import { extractRemoteImages, classifyPayload } from './parse';
+
+describe('extractRemoteImages', () => {
+  test('collects absolute http(s) sources', () => {
+    const html = '<p>text</p><img src="https://example.com/a.png"><img src="http://example.com/b.jpg">';
+
+    assert.deepEqual(extractRemoteImages(html), ['https://example.com/a.png', 'http://example.com/b.jpg']);
+  });
+
+  test('ignores data: and blob: sources, which need no download', () => {
+    const html = '<img src="data:image/png;base64,iVBOR"><img src="blob:http://x/y"><img src="https://example.com/a.png">';
+
+    assert.deepEqual(extractRemoteImages(html), ['https://example.com/a.png']);
+  });
+
+  test('ignores javascript: and other schemes', () => {
+    const html = '<img src="javascript:alert(1)"><img src="file:///etc/passwd"><img src="ftp://example.com/a.png">';
+
+    assert.deepEqual(extractRemoteImages(html), []);
+  });
+
+  test('ignores relative sources, which cannot be resolved outside their origin', () => {
+    const html = '<img src="/images/a.png"><img src="../b.png">';
+
+    assert.deepEqual(extractRemoteImages(html), []);
+  });
+
+  test('deduplicates repeated sources so one upload covers every occurrence', () => {
+    const html = '<img src="https://example.com/a.png"><img src="https://example.com/a.png">';
+
+    assert.deepEqual(extractRemoteImages(html), ['https://example.com/a.png']);
+  });
+
+  test('handles single quotes and extra attributes', () => {
+    const html = `<img loading="lazy" src='https://example.com/a.png' width="20" alt="x">`;
+
+    assert.deepEqual(extractRemoteImages(html), ['https://example.com/a.png']);
+  });
+
+  test('decodes HTML entities in the URL, as real clipboard HTML contains them', () => {
+    // Wikipedia's clipboard HTML carries query strings escaped this way.
+    const html = '<img src="https://example.com/a.png?utm_source=x&amp;utm_campaign=y">';
+
+    assert.deepEqual(extractRemoteImages(html), ['https://example.com/a.png?utm_source=x&utm_campaign=y']);
+  });
+
+  test('returns nothing for html without images', () => {
+    assert.deepEqual(extractRemoteImages('<p>just text</p>'), []);
+    assert.deepEqual(extractRemoteImages(''), []);
+  });
+});
+
+describe('classifyPayload', () => {
+  test('files take precedence: a screenshot needs no HTML handling', () => {
+    assert.equal(classifyPayload({ files: 1, html: false, text: false }), 'files');
+    assert.equal(classifyPayload({ files: 1, html: true, text: true }), 'files');
+  });
+
+  test('html without files is rich content', () => {
+    assert.equal(classifyPayload({ files: 0, html: true, text: true }), 'rich');
+  });
+
+  test('text alone is plain', () => {
+    assert.equal(classifyPayload({ files: 0, html: false, text: true }), 'plain');
+  });
+
+  test('nothing usable is empty', () => {
+    assert.equal(classifyPayload({ files: 0, html: false, text: false }), 'empty');
+  });
+});

--- a/frontend/app/helpers/clipboard/parse.ts
+++ b/frontend/app/helpers/clipboard/parse.ts
@@ -1,0 +1,79 @@
+/**
+ * Clipboard analysis: turn a DataTransfer into a normalized description of what was
+ * pasted or dropped, without touching the network or any store. The import step
+ * (./import) decides what to do with it.
+ */
+
+export type ClipboardKind = 'files' | 'rich' | 'plain' | 'empty';
+
+export interface ClipboardPayload {
+  kind: ClipboardKind;
+  /** Real file entries: screenshots, copied image files, dropped files. */
+  files: File[];
+  /** text/html, when the source offered formatting. */
+  html?: string;
+  /** text/plain, the fallback every source provides. */
+  text?: string;
+  /** Absolute image URLs found in the HTML, which have to be fetched separately. */
+  remoteImages: string[];
+}
+
+/**
+ * Files win over HTML: a screenshot or a copied image arrives as a file entry and
+ * needs no HTML handling, while the accompanying HTML would only duplicate it.
+ */
+export function classifyPayload({ files, html, text }: { files: number; html: boolean; text: boolean }): ClipboardKind {
+  if (files > 0) return 'files';
+  if (html) return 'rich';
+  if (text) return 'plain';
+  return 'empty';
+}
+
+/**
+ * Collect the image sources worth downloading. Relative paths are skipped because
+ * they cannot be resolved outside their original origin, and data:/blob: sources
+ * are already self-contained. Restricting to http(s) also keeps the fetch step from
+ * being pointed at other schemes.
+ */
+export function extractRemoteImages(html: string): string[] {
+  if (!html) return [];
+
+  const urls = new Set<string>();
+
+  for (const match of html.matchAll(/<img\b[^>]*?\bsrc\s*=\s*("([^"]*)"|'([^']*)')/gi)) {
+    const raw = (match[2] ?? match[3] ?? '').trim();
+    if (!raw) continue;
+
+    // Clipboard HTML escapes query separators, so &amp; has to become & before use.
+    const url = decodeEntities(raw);
+    if (/^https?:\/\//i.test(url)) urls.add(url);
+  }
+
+  return [...urls];
+}
+
+function decodeEntities(value: string): string {
+  return value
+    .replace(/&amp;/gi, '&')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#0?39;|&apos;/gi, "'");
+}
+
+/** Read a paste or drop event's data into a payload. */
+export function parseClipboard(data: DataTransfer | null): ClipboardPayload {
+  if (!data) return { kind: 'empty', files: [], remoteImages: [] };
+
+  const files = [...(data.files ?? [])];
+  const html = data.getData('text/html') || undefined;
+  const text = data.getData('text/plain') || undefined;
+
+  return {
+    kind: classifyPayload({ files: files.length, html: !!html, text: !!text }),
+    files,
+    html,
+    text,
+    remoteImages: html ? extractRemoteImages(html) : [],
+  };
+}

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -15,6 +15,7 @@
         "@nuxtjs/color-mode": "^4.0.1",
         "@nuxtjs/i18n": "10.6.0",
         "@pinia/nuxt": "^1.0.2",
+        "@types/turndown": "^5.0.6",
         "@zip.js/zip.js": "^2.8.59",
         "etag": "^1.8.1",
         "fast-glob": "^3.3.3",
@@ -38,6 +39,7 @@
         "sass": "^1.103.1",
         "svg-baker": "^1.7.0",
         "svgo": "^4.1.0",
+        "turndown": "^7.2.4",
         "vue": "^3.5.41",
       },
       "devDependencies": {
@@ -480,6 +482,8 @@
 
     "@mermaid-js/parser": ["@mermaid-js/parser@1.2.1", "", { "dependencies": { "@chevrotain/types": "~11.1.2" } }, "sha512-n12NohV3mrUyUL2o93IgG/ifeW9FTyeJn3zDxkhwa8MJ9Fxg3HQMlA3RiGmD/3UnJvheztkjjQAjA2T4LmUcpw=="],
 
+    "@mixmark-io/domino": ["@mixmark-io/domino@2.2.0", "", {}, "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw=="],
+
     "@miyaneee/rollup-plugin-json5": ["@miyaneee/rollup-plugin-json5@1.2.0", "", { "dependencies": { "@rollup/pluginutils": "^5.1.0", "json5": "^2.2.3" }, "peerDependencies": { "rollup": "^1.20.0 || ^2.0.0 || ^3.0.0 || ^4.0.0" } }, "sha512-JjTIaXZp9WzhUHpElrqPnl1AzBi/rvRs065F71+aTmlqvTMVkdbjZ8vfFl4nRlgJy+TPBw69ZK4pwFdmOAt4aA=="],
 
     "@napi-rs/canvas": ["@napi-rs/canvas@1.0.7", "", { "optionalDependencies": { "@napi-rs/canvas-android-arm64": "1.0.7", "@napi-rs/canvas-darwin-arm64": "1.0.7", "@napi-rs/canvas-darwin-x64": "1.0.7", "@napi-rs/canvas-linux-arm-gnueabihf": "1.0.7", "@napi-rs/canvas-linux-arm64-gnu": "1.0.7", "@napi-rs/canvas-linux-arm64-musl": "1.0.7", "@napi-rs/canvas-linux-riscv64-gnu": "1.0.7", "@napi-rs/canvas-linux-x64-gnu": "1.0.7", "@napi-rs/canvas-linux-x64-musl": "1.0.7", "@napi-rs/canvas-win32-arm64-msvc": "1.0.7", "@napi-rs/canvas-win32-x64-msvc": "1.0.7" } }, "sha512-26wVFEgs6gbe7wmzCrud1pK8q6oOgcUu7OOF24BuazB8ZUCskU9ZSLrCjoWIFVxx09rjAxsXxPleaWowHvdPCA=="],
@@ -883,6 +887,8 @@
     "@types/resolve": ["@types/resolve@1.20.2", "", {}, "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q=="],
 
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
+
+    "@types/turndown": ["@types/turndown@5.0.6", "", {}, "sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.67.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.67.0", "@typescript-eslint/type-utils": "8.67.0", "@typescript-eslint/utils": "8.67.0", "@typescript-eslint/visitor-keys": "8.67.0", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.67.0", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-Un7Heoyj65NREbKAyIrFxeM143NZpExWmy1Nep4DLeQOeLlTeumPjoNKnBrU5D5moWXbPJgRa5Uwcdu0faVNGQ=="],
 
@@ -2567,6 +2573,8 @@
     "ts-dedent": ["ts-dedent@2.3.0", "", {}, "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "turndown": ["turndown@7.2.4", "", { "dependencies": { "@mixmark-io/domino": "^2.2.0" } }, "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ=="],
 
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 

--- a/frontend/i18n/locales/de/components.ts
+++ b/frontend/i18n/locales/de/components.ts
@@ -38,6 +38,10 @@ export default {
   },
 
   editor: {
+    clipboard: {
+      partialImport: '{uploaded} importiert. {remaining} verweisen weiterhin auf den Ursprungsort, der keinen Zugriff erlaubt hat.',
+      partialImportTitle: 'Einige Bilder wurden nicht importiert',
+    },
     placeholder: {
       description: 'Dokumentbeschreibung',
       title: 'Dokumenttitel',

--- a/frontend/i18n/locales/en/components.ts
+++ b/frontend/i18n/locales/en/components.ts
@@ -38,6 +38,10 @@ export default {
   },
 
   editor: {
+    clipboard: {
+      partialImport: '{uploaded} imported. {remaining} still link to their original location, which did not allow access.',
+      partialImportTitle: 'Some images were not imported',
+    },
     placeholder: {
       description: 'Document description',
       title: 'Document title',

--- a/frontend/i18n/locales/fr/components.ts
+++ b/frontend/i18n/locales/fr/components.ts
@@ -38,6 +38,10 @@ export default {
   },
 
   editor: {
+    clipboard: {
+      partialImport: '{uploaded} importée(s). {remaining} pointent toujours vers leur emplacement d\'origine, qui n\'a pas autorisé l\'accès.',
+      partialImportTitle: 'Certaines images n\'ont pas été importées',
+    },
     placeholder: {
       description: 'Document description',
       title: 'Document title',

--- a/frontend/i18n/locales/it/components.ts
+++ b/frontend/i18n/locales/it/components.ts
@@ -38,6 +38,10 @@ export default {
   },
 
   editor: {
+    clipboard: {
+      partialImport: '{uploaded} importate. {remaining} rimandano ancora alla posizione originale, che non ha consentito l\'accesso.',
+      partialImportTitle: 'Alcune immagini non sono state importate',
+    },
     placeholder: {
       description: 'Descrizione del documento',
       title: 'Titolo del documento',

--- a/frontend/i18n/locales/ko/components.ts
+++ b/frontend/i18n/locales/ko/components.ts
@@ -38,6 +38,10 @@ export default {
   },
 
   editor: {
+    clipboard: {
+      partialImport: '{uploaded}개를 가져왔습니다. {remaining}개는 접근이 허용되지 않아 원래 위치를 계속 참조합니다.',
+      partialImportTitle: '일부 이미지를 가져오지 못했습니다',
+    },
     placeholder: {
       description: '문서 설명',
       title: '문서 제목',

--- a/frontend/i18n/locales/uk/components.ts
+++ b/frontend/i18n/locales/uk/components.ts
@@ -38,6 +38,10 @@ export default {
   },
 
   editor: {
+    clipboard: {
+      partialImport: 'Імпортовано: {uploaded}. Ще {remaining} посилаються на початкове розташування, яке не дозволило доступ.',
+      partialImportTitle: 'Деякі зображення не вдалося імпортувати',
+    },
     placeholder: {
       description: 'Опис документа',
       title: 'Назва документа',

--- a/frontend/i18n/locales/zh-CN/components.ts
+++ b/frontend/i18n/locales/zh-CN/components.ts
@@ -38,6 +38,10 @@ export default {
   },
 
   editor: {
+    clipboard: {
+      partialImport: '已导入 {uploaded} 张。另有 {remaining} 张仍指向原始位置，该位置不允许访问。',
+      partialImportTitle: '部分图片未能导入',
+    },
     placeholder: {
       description: '文档描述',
       title: '文档标题',

--- a/frontend/i18n/locales/zh-TW/components.ts
+++ b/frontend/i18n/locales/zh-TW/components.ts
@@ -38,6 +38,10 @@ export default {
   },
 
   editor: {
+    clipboard: {
+      partialImport: '已匯入 {uploaded} 張。另有 {remaining} 張仍指向原始位置，該位置不允許存取。',
+      partialImportTitle: '部分圖片未能匯入',
+    },
     placeholder: {
       description: '文件描述',
       title: '文件標題',

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "@nuxtjs/color-mode": "^4.0.1",
     "@nuxtjs/i18n": "10.6.0",
     "@pinia/nuxt": "^1.0.2",
+    "@types/turndown": "^5.0.6",
     "@zip.js/zip.js": "^2.8.59",
     "etag": "^1.8.1",
     "fast-glob": "^3.3.3",
@@ -35,6 +36,7 @@
     "sass": "^1.103.1",
     "svg-baker": "^1.7.0",
     "svgo": "^4.1.0",
+    "turndown": "^7.2.4",
     "vue": "^3.5.41"
   },
   "scripts": {


### PR DESCRIPTION
Pasting from a browser only kept the plain text: formatting was dropped, and images were lost entirely, because a page's images usually arrive as <img src> in text/html rather than as clipboard files.

Paste and drop now go through a clipboard import module that splits the payload into its parts and stores each one:

- helpers/clipboard/parse.ts classifies a DataTransfer and collects the absolute image URLs from its HTML
- helpers/clipboard/html-to-markdown.ts converts the HTML, dropping the inline styles and wrapper elements browsers copy along
- helpers/clipboard/import.ts uploads files and remote images as resources and rewrites the markdown to reference the stored copies

Remote images are fetched in the browser, so a source that sends no CORS headers cannot be stored locally; those keep their original URL and the reader is told how many were left behind. Uploads run one at a time, and a paste is capped at 20 remote images so one paste cannot flood the store.

Both editor handlers previously carried the same upload block; they now share this path.