### PR TITLE
feat(markdown): show the language of a code block

### DIFF
--- a/frontend/app/helpers/markdown/code-block.test.ts
+++ b/frontend/app/helpers/markdown/code-block.test.ts
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+import MarkdownIt from 'markdown-it';
+
+import { copyCodePlugin, resolveLanguageLabel } from './code-block';
+
+function render(source: string): string {
+  const md = new MarkdownIt({ html: true, linkify: true });
+  md.use(copyCodePlugin);
+  return md.render(source);
+}
+
+describe('resolveLanguageLabel', () => {
+  test('maps common aliases to their conventional display name', () => {
+    assert.equal(resolveLanguageLabel('js'), 'JavaScript');
+    assert.equal(resolveLanguageLabel('javascript'), 'JavaScript');
+    assert.equal(resolveLanguageLabel('ts'), 'TypeScript');
+    assert.equal(resolveLanguageLabel('py'), 'Python');
+    assert.equal(resolveLanguageLabel('sh'), 'Bash');
+    assert.equal(resolveLanguageLabel('java'), 'Java');
+  });
+
+  test('is case insensitive on the hint', () => {
+    assert.equal(resolveLanguageLabel('JS'), 'JavaScript');
+    assert.equal(resolveLanguageLabel('Java'), 'Java');
+  });
+
+  test('falls back to the hint itself for languages it does not know', () => {
+    assert.equal(resolveLanguageLabel('zig'), 'zig');
+    assert.equal(resolveLanguageLabel('my-dsl'), 'my-dsl');
+  });
+
+  test('ignores anything after the language hint, as highlight.js does', () => {
+    // ```js {1,3} highlights lines; the label should still read JavaScript.
+    assert.equal(resolveLanguageLabel('js {1,3}'), 'JavaScript');
+    assert.equal(resolveLanguageLabel('java title="Example.java"'), 'Java');
+  });
+
+  test('returns an empty label when no language was given', () => {
+    assert.equal(resolveLanguageLabel(''), '');
+    assert.equal(resolveLanguageLabel('   '), '');
+  });
+});
+
+describe('copyCodePlugin', () => {
+  test('labels a fenced block with its language', () => {
+    const html = render('```java\nclass A {}\n```');
+
+    assert.match(html, /<span class="code-block-language">Java<\/span>/);
+  });
+
+  test('keeps the copy button', () => {
+    const html = render('```java\nclass A {}\n```');
+
+    assert.match(html, /class="code-copy-btn"/);
+  });
+
+  test('omits the label for a block without a language', () => {
+    const html = render('```\nplain text\n```');
+
+    assert.doesNotMatch(html, /code-block-language/);
+    assert.match(html, /class="code-copy-btn"/, 'the copy button stays regardless');
+  });
+
+  test('omits the label for an indented code block, which has no language', () => {
+    const html = render('    indented code\n');
+
+    assert.doesNotMatch(html, /code-block-language/);
+  });
+
+  test('escapes the language hint so it cannot inject markup', () => {
+    const html = render('```<img src=x onerror=alert(1)>\ncode\n```');
+
+    assert.doesNotMatch(html, /<img/);
+    assert.match(html, /&lt;img/);
+  });
+
+  test('wraps the block so the label can be positioned against it', () => {
+    const html = render('```js\nconst a = 1;\n```');
+
+    assert.match(html, /<div class="code-block-wrapper">/);
+    assert.match(html, /<span class="code-block-language">JavaScript<\/span>/);
+  });
+});

--- a/frontend/app/helpers/markdown/code-block.ts
+++ b/frontend/app/helpers/markdown/code-block.ts
@@ -1,24 +1,106 @@
 import type { MarkdownIt } from 'markdown-it';
 
 /**
- * This plugin adds a copy button to code blocks in the rendered markdown.
+ * This plugin adds a copy button and a language label to code blocks in the
+ * rendered markdown.
  */
 
 const ICON_COPY = `<svg class="copy-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>`;
 const ICON_CHECK = `<svg class="check-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>`;
+
+/**
+ * Conventional casing for the hints people actually type. Anything absent here is
+ * shown as written, so an unlisted language still gets a label.
+ */
+const LANGUAGE_LABELS: Record<string, string> = {
+  bash: 'Bash',
+  c: 'C',
+  'c++': 'C++',
+  cpp: 'C++',
+  cs: 'C#',
+  csharp: 'C#',
+  css: 'CSS',
+  diff: 'Diff',
+  docker: 'Dockerfile',
+  dockerfile: 'Dockerfile',
+  go: 'Go',
+  golang: 'Go',
+  graphql: 'GraphQL',
+  html: 'HTML',
+  ini: 'INI',
+  java: 'Java',
+  javascript: 'JavaScript',
+  js: 'JavaScript',
+  json: 'JSON',
+  jsx: 'JSX',
+  kotlin: 'Kotlin',
+  kt: 'Kotlin',
+  latex: 'LaTeX',
+  less: 'Less',
+  lua: 'Lua',
+  makefile: 'Makefile',
+  markdown: 'Markdown',
+  md: 'Markdown',
+  nginx: 'Nginx',
+  objectivec: 'Objective-C',
+  php: 'PHP',
+  powershell: 'PowerShell',
+  ps1: 'PowerShell',
+  py: 'Python',
+  python: 'Python',
+  r: 'R',
+  rb: 'Ruby',
+  ruby: 'Ruby',
+  rs: 'Rust',
+  rust: 'Rust',
+  scala: 'Scala',
+  scss: 'SCSS',
+  sh: 'Bash',
+  shell: 'Shell',
+  sql: 'SQL',
+  swift: 'Swift',
+  tex: 'TeX',
+  toml: 'TOML',
+  ts: 'TypeScript',
+  tsx: 'TSX',
+  typescript: 'TypeScript',
+  vue: 'Vue',
+  xml: 'XML',
+  yaml: 'YAML',
+  yml: 'YAML',
+  zsh: 'Zsh',
+};
+
+/**
+ * Resolve the label for a fence's info string. Only the first word is the language:
+ * highlight.js ignores the rest, and so do we, so `js {1,3}` still reads JavaScript.
+ */
+export function resolveLanguageLabel(info: string): string {
+  const hint = info.trim().split(/\s+/)[0] ?? '';
+  if (!hint) return '';
+
+  return LANGUAGE_LABELS[hint.toLowerCase()] ?? hint;
+}
 
 export const copyCodePlugin = (md: MarkdownIt) => {
   const defaultFence = md.renderer.rules.fence;
 
   md.renderer.rules.fence = function (tokens, idx, options, env, self) {
     const original = defaultFence ? defaultFence(tokens, idx, options, env, self) : self.renderToken(tokens, idx, options);
+    const label = resolveLanguageLabel(tokens[idx]?.info ?? '');
+
+    // The hint comes from the document, so it is escaped like any other content.
+    const languageTag = label ? `<span class="code-block-language">${md.utils.escapeHtml(label)}</span>` : '';
 
     return `
 <div class="code-block-wrapper">
-  <button type="button" class="code-copy-btn" aria-label="Copy code" title="Copy code">
-    <span class="btn-icon">${ICON_COPY}</span>
-    <span class="btn-icon-success">${ICON_CHECK}</span>
-  </button>
+  <div class="code-block-actions">
+    ${languageTag}
+    <button type="button" class="code-copy-btn" aria-label="Copy code" title="Copy code">
+      <span class="btn-icon">${ICON_COPY}</span>
+      <span class="btn-icon-success">${ICON_CHECK}</span>
+    </button>
+  </div>
   ${original}
 </div>`;
   };

--- a/frontend/app/styles/features/markdown.scss
+++ b/frontend/app/styles/features/markdown.scss
@@ -171,11 +171,35 @@
 	margin: 1em 0;
 }
 
-.code-copy-btn {
+// Language label and copy button share one row, pinned to the top-right of the block.
+.code-block-actions {
 	position: absolute;
 	top: 20px;
 	right: 8px;
 	z-index: 5;
+	display: flex;
+	align-items: center;
+	gap: 6px;
+}
+
+.code-block-language {
+	padding: 4px 8px;
+	border: 1px solid var(--grey-dark);
+	border-radius: 6px;
+	font-family: var(--font-mono, monospace);
+	font-size: 0.72rem;
+	font-weight: 500;
+	color: #a0a0a0;
+	letter-spacing: 0.02em;
+	white-space: nowrap;
+	background: rgb(30 30 30 / 70%);
+	backdrop-filter: blur(4px);
+	user-select: none;
+}
+
+.code-copy-btn {
+	/* Positioning context for the success tick, which is absolutely placed. */
+	position: relative;
 	display: inline-flex;
 	justify-content: center;
 	align-items: center;


### PR DESCRIPTION
A fenced block's language hint drove the syntax highlighting but was not visible in the rendered document. It now appears as a tag in the block's top-right corner, beside the copy button.

Known hints are shown with their conventional casing (js and javascript both read JavaScript), and an unlisted one is shown as written, so any language still gets a label. Only the first word of the info string is used, matching highlight.js, so `js {1,3}` still reads JavaScript. Blocks without a hint keep just the copy button.

The label and the button now share a flex row instead of the button being positioned on its own.