### PR TITLE
fix(ui): tooltip overflow and unify document editor input styling (#727)

### DIFF
--- a/frontend/app/components/AppTagInput.vue
+++ b/frontend/app/components/AppTagInput.vue
@@ -169,13 +169,34 @@ input {
   }
 
   &.minimal {
-    padding: 6px 8px;
-    border: none;
-    font-size: 13px;
+    box-sizing: border-box;
+    height: 34px;
+    padding: 0 12px;
+    border: 1px solid transparent;
+    border-radius: var(--radius-md);
+    font-family: inherit;
+    font-size: 0.9rem;
+    font-weight: 500;
+    color: var(--text-primary);
+    background: var(--surface-raised);
+    outline: none;
+    transition: all $transition-base ease;
 
-    &:hover,
+    &:hover {
+      border-color: var(--border);
+      background: var(--surface-overlay);
+    }
+
     &:focus {
-      background: var(--surface-transparent);
+      border-color: var(--primary);
+      background: var(--surface-base);
+      box-shadow: 0 0 0 3px color-mix(in srgb, var(--primary) 15%, transparent);
+    }
+
+    &::placeholder {
+      font-weight: 400;
+      color: var(--text-secondary);
+      opacity: 0.8;
     }
   }
 }

--- a/frontend/app/components/MarkdownEditor/MarkdownEditor.vue
+++ b/frontend/app/components/MarkdownEditor/MarkdownEditor.vue
@@ -233,6 +233,8 @@ const autoSave = debounceDelayed(() => {
     display: flex;
     flex-wrap: wrap;
     align-items: center;
+    gap: 12px;
+    margin-bottom: 8px;
   }
 
   gap: 8px;
@@ -244,49 +246,70 @@ const autoSave = debounceDelayed(() => {
 
 .meta-title {
   flex: 0 1 auto;
-  min-width: 120px;
-  max-width: 280px;
-  padding: 4px 8px;
-  border: none;
-  border-radius: var(--radius-sm);
-  font-size: 1rem;
-  font-weight: 600;
+  box-sizing: border-box;
+  min-width: 140px;
+  max-width: 320px;
+  height: 34px;
+  padding: 0 12px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  font-family: inherit;
+  font-size: 0.9rem;
+  font-weight: 500;
   color: var(--text-primary);
-  background: transparent;
+  background: var(--surface-raised);
   outline: none;
-  transition: background $transition-fast ease;
+  transition: all $transition-base ease;
 
-  &:hover,
+  &:hover {
+    border-color: var(--border);
+    background: var(--surface-overlay);
+  }
+
   &:focus {
-    background: var(--surface-transparent);
+    border-color: var(--primary);
+    background: var(--surface-base);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--primary) 15%, transparent);
   }
 
   &::placeholder {
-    font-weight: 500;
+    font-weight: 400;
     color: var(--text-secondary);
+    opacity: 0.8;
   }
 }
 
 .meta-description {
-  flex: 1 1 150px;
-  min-width: 100px;
-  padding: 4px 8px;
-  border: none;
-  border-radius: var(--radius-sm);
-  font-size: 0.85rem;
-  color: var(--text-body);
-  background: transparent;
+  flex: 1 1 200px;
+  box-sizing: border-box;
+  min-width: 150px;
+  height: 34px;
+  padding: 0 12px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  font-family: inherit;
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--text-primary);
+  background: var(--surface-raised);
   outline: none;
-  transition: background $transition-fast ease;
+  transition: all $transition-base ease;
 
-  &:hover,
+  &:hover {
+    border-color: var(--border);
+    background: var(--surface-overlay);
+  }
+
   &:focus {
-    background: var(--surface-transparent);
+    border-color: var(--primary);
+    background: var(--surface-base);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--primary) 15%, transparent);
   }
 
   &::placeholder {
+    font-weight: 400;
     color: var(--text-secondary);
-    opacity: 0.7;
+    opacity: 0.8;
   }
 }
 

--- a/frontend/app/components/MarkdownEditor/Toolbar.vue
+++ b/frontend/app/components/MarkdownEditor/Toolbar.vue
@@ -226,7 +226,6 @@ const actionTools = computed<ToolItem[]>(() => [{ name: t('markdown.toolbar.prev
   background: var(--surface-base);
   box-shadow: var(--shadow-sm);
   transition: box-shadow $transition-base ease;
-  overflow-x: clip;
   user-select: none;
 
   &:hover {
@@ -270,6 +269,23 @@ const actionTools = computed<ToolItem[]>(() => [{ name: t('markdown.toolbar.prev
       opacity: 1;
       visibility: visible;
       transform: translateX(-50%) translateY(0);
+    }
+  }
+
+  /* Fix clipping for the very first button (Bold) */
+  .toolbar-group:first-of-type .group-buttons &:first-child {
+    .tooltip {
+      left: 0;
+      transform: translateY(-4px);
+
+      &::before {
+        left: 9px;
+        transform: none;
+      }
+    }
+
+    &:hover .tooltip {
+      transform: translateY(0);
     }
   }
 }
@@ -405,6 +421,25 @@ const actionTools = computed<ToolItem[]>(() => [{ name: t('markdown.toolbar.prev
   padding: 3px;
   border-radius: var(--radius-sm);
   background: var(--surface-transparent);
+
+  /* Fix clipping for right-aligned buttons */
+  .toolbar-btn {
+    .tooltip {
+      right: 0;
+      left: auto;
+      transform: translateY(-4px);
+
+      &::before {
+        right: 9px;
+        left: auto;
+        transform: none;
+      }
+    }
+
+    &:hover .tooltip {
+      transform: translateY(0);
+    }
+  }
 }
 
 .action-divider {


### PR DESCRIPTION
fix(ui): fix editor tooltip clipping and enhance metadata input styling

- Fix tooltip clipping on far left/right toolbar buttons
- Redesign Document Title, Description, and Tag inputs for a unified premium aesthetic
- Enforce strict height and alignment across all editor inputs
