### PR TITLE
fix(frontend): restore accent theme-color on PWA startup

### DIFF
--- a/frontend/app/composables/useAppColors.ts
+++ b/frontend/app/composables/useAppColors.ts
@@ -1,4 +1,5 @@
 import { appColors } from '~/helpers/constants';
+import { persistThemeColor, resolveThemeColorValue } from '~/helpers/themeColor';
 
 /** Get theme color name by index (-2 = primary, -1 = none, 0+ = color index) */
 function getAppAccent(index: number = 0, defaultPrimary?: boolean): string {
@@ -32,8 +33,10 @@ function setThemeColor(cssVar: string) {
     meta.setAttribute('name', 'theme-color');
     document.head.appendChild(meta);
   }
-  const computedColor = getComputedStyle(document.documentElement).getPropertyValue(cssVar).trim();
+  const styles = getComputedStyle(document.documentElement);
+  const computedColor = resolveThemeColorValue(styles.getPropertyValue(cssVar).trim(), name => styles.getPropertyValue(name).trim());
   meta.setAttribute('content', computedColor);
+  persistThemeColor(computedColor);
 }
 
 export const useAppColors = () => {

--- a/frontend/app/helpers/themeColor.test.ts
+++ b/frontend/app/helpers/themeColor.test.ts
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+import { persistThemeColor, readStoredThemeColor, resolveThemeColorValue } from './themeColor';
+
+function installStorageMock() {
+  const store = new Map<string, string>();
+  (globalThis as unknown as { window: unknown }).window = {
+    localStorage: {
+      getItem: (key: string) => store.get(key) ?? null,
+      removeItem: (key: string) => {
+        store.delete(key);
+      },
+      setItem: (key: string, value: string) => {
+        store.set(key, value);
+      },
+    },
+  };
+  return store;
+}
+
+describe('resolveThemeColorValue', () => {
+  test('unwraps a `var(--…)` reference into its concrete value', () => {
+    const get = (name: string) => ({ '--accent': '#0c60d9' })[name] ?? '';
+    assert.equal(resolveThemeColorValue('var(--accent)', get), '#0c60d9');
+  });
+
+  test('returns plain color values unchanged', () => {
+    const get = () => '';
+    assert.equal(resolveThemeColorValue('#1c8f59', get), '#1c8f59');
+  });
+});
+
+describe('theme color persistence', () => {
+  test('stores the applied color so it can be restored synchronously on next startup', () => {
+    const store = installStorageMock();
+    persistThemeColor('#1c8f59');
+
+    assert.equal(store.get('alexandrie-theme-color'), '#1c8f59');
+    assert.equal(readStoredThemeColor(), '#1c8f59');
+  });
+
+  test('clears the stored color when the accent is unset', () => {
+    installStorageMock();
+    persistThemeColor('#1c8f59');
+    persistThemeColor('');
+
+    assert.equal(readStoredThemeColor(), '');
+  });
+});
+
+describe('startup restore', () => {
+  test('re-applies the persisted accent color to the theme-color meta on load', () => {
+    installStorageMock();
+    persistThemeColor('#1c8f59');
+
+    // Mirrors the inline head script: restore before the app renders.
+    const meta = { content: '#3956e7' };
+    const stored = readStoredThemeColor();
+    if (stored) meta.content = stored;
+
+    assert.equal(meta.content, '#1c8f59');
+  });
+
+  test('falls back to the default color when nothing was persisted', () => {
+    installStorageMock();
+
+    const meta = { content: '#3956e7' };
+    const stored = readStoredThemeColor();
+    if (stored) meta.content = stored;
+
+    assert.equal(meta.content, '#3956e7');
+  });
+});

--- a/frontend/app/helpers/themeColor.ts
+++ b/frontend/app/helpers/themeColor.ts
@@ -1,0 +1,32 @@
+export const THEME_COLOR_STORAGE_KEY = 'alexandrie-theme-color';
+
+/** Resolve a CSS custom property value, unwrapping a single `var(--…)` reference. */
+export function resolveThemeColorValue(value: string, get: (name: string) => string): string {
+  const reference = value.match(/^var\((--[\w-]+)\)$/);
+  if (reference) {
+    return get(reference[1]);
+  }
+  return value;
+}
+
+/** Persist the applied theme color so it can be restored synchronously on next startup. */
+export function persistThemeColor(color: string): void {
+  try {
+    if (color) {
+      window.localStorage.setItem(THEME_COLOR_STORAGE_KEY, color);
+    } else {
+      window.localStorage.removeItem(THEME_COLOR_STORAGE_KEY);
+    }
+  } catch {
+    // Storage may be unavailable (e.g. private browsing); the meta tag is still updated.
+  }
+}
+
+/** Read the persisted theme color, if any. */
+export function readStoredThemeColor(): string {
+  try {
+    return window.localStorage.getItem(THEME_COLOR_STORAGE_KEY) || '';
+  } catch {
+    return '';
+  }
+}

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -1,5 +1,6 @@
 import { defineNuxtConfig } from 'nuxt/config';
 import { resolve } from 'path';
+import { THEME_COLOR_STORAGE_KEY } from './app/helpers/themeColor';
 import { createSvgIconsPlugin } from './vite/plugins/svg-sprite';
 import type { NuxtPage } from 'nuxt/schema';
 
@@ -89,6 +90,11 @@ export default defineNuxtConfig({
           --primary-border: var(--accent-border);
         }
       `,
+        },
+      ],
+      script: [
+        {
+          innerHTML: `(function(){try{var c=window.localStorage.getItem(${JSON.stringify(THEME_COLOR_STORAGE_KEY)});if(!c)return;var m=document.querySelector('meta[name="theme-color"]');if(!m){m=document.createElement('meta');m.setAttribute('name','theme-color');document.head.appendChild(m);}m.setAttribute('content',c);}catch(e){}})();`,
         },
       ],
     },


### PR DESCRIPTION
## Summary

Preference accent color is not loaded at the startup of PWA. The fix is minimal: `import { persistThemeColor, resolveThemeColorValue } from '~/helpers/themeColor';` in `useAppColors.ts`.

## What changed

- Fixed the issue in `frontend/app/composables/useAppColors.ts`.
- Fixed the issue in `frontend/app/helpers/themeColor.test.ts`.
- Fixed the issue in `frontend/app/helpers/themeColor.ts`.
- Fixed the issue in `frontend/nuxt.config.ts`.

## Why this fixes the issue

Preference accent color is not loaded at the startup of PWA. The change targets the affected code path (`frontend/app/composables/useAppColors.ts`, `frontend/app/helpers/themeColor.test.ts`, `frontend/app/helpers/themeColor.ts`) and eliminates the faulty behavior.

## Testing

Ran the NOT APPLICABLE — no test suite or runnable test command is defined in the repository..

## Review

The change addresses the reported issue well: the applied theme-color is now persisted to localStorage and restored synchronously via an inline head script before first paint, and var() references are unwrapped so the persisted meta content is a concrete color. The helper logic is clean, defensive (try/catch around storage), and the new tests cover the core helper behavior. Main concerns are a possible node-side typecheck break from importing a `window`-touching module into nuxt.config.ts, a brief wrong-color flash when the persisted color is stale relative to the backend/user preference or active color mode, and that the tests never run in CI and don't exercise the real integration. No blocking findings; advisory findings (LOW: 2, MEDIUM: 1).

Fixes #758