### PR TITLE
feat: add hierarchical graph view for categories and teams

### DIFF
--- a/frontend/app/components/Node/GraphNode.vue
+++ b/frontend/app/components/Node/GraphNode.vue
@@ -1,0 +1,34 @@
+<template>
+  <li v-for="node in nodes" :key="node.id">
+    <div class="node-card" @click="handleClick(node)">
+      <Icon v-if="node.icon" :name="node.icon" />
+      <Icon v-else :name="node.children ? 'folder' : 'document'" />
+      <span class="node-label">{{ node.label }}</span>
+    </div>
+    
+    <ul v-if="node.children && node.children.length > 0">
+      <GraphNode :nodes="node.children" @node-click="handleClick" />
+    </ul>
+  </li>
+</template>
+
+<script setup lang="ts">
+import type { TreeItem } from '~/helpers/TreeBuilder';
+import type { Node } from '~/stores';
+
+defineOptions({
+  name: 'GraphNode'
+});
+
+defineProps<{
+  nodes: TreeItem<Node>[];
+}>();
+
+const emit = defineEmits<{
+  (e: 'node-click', node: TreeItem<Node>): void;
+}>();
+
+function handleClick(node: TreeItem<Node>) {
+  emit('node-click', node);
+}
+</script>

--- a/frontend/app/components/Node/GraphView.vue
+++ b/frontend/app/components/Node/GraphView.vue
@@ -1,0 +1,156 @@
+<template>
+  <div class="graph-view-container">
+    <div class="tree">
+      <ul>
+        <GraphNode :nodes="nodes" @node-click="handleClick" />
+      </ul>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { TreeItem } from '~/helpers/TreeBuilder';
+import type { Node } from '~/stores';
+import GraphNode from './GraphNode.vue';
+
+defineProps<{
+  nodes: TreeItem<Node>[];
+}>();
+
+const emit = defineEmits<{
+  (e: 'node-click', node: TreeItem<Node>): void;
+}>();
+
+function handleClick(node: TreeItem<Node>) {
+  emit('node-click', node);
+}
+</script>
+
+<style lang="scss">
+.graph-view-container {
+  width: 100%;
+  padding: 40px 20px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  background: var(--surface-base);
+  overflow: auto hidden;
+}
+
+/* CSS Tree Layout */
+.graph-view-container .tree {
+  display: flex;
+  justify-content: center;
+
+  ul {
+    position: relative;
+    display: flex;
+    margin: 0;
+    padding-top: 20px;
+    padding-left: 0;
+    transition: all 0.5s;
+  }
+
+  li {
+    position: relative;
+    float: left;
+    padding: 20px 5px 0;
+    text-align: center;
+    transition: all 0.5s;
+    list-style-type: none;
+  }
+
+  /* We will use ::before and ::after to draw the connectors */
+  li::before, li::after {
+    position: absolute;
+    top: 0;
+    right: 50%;
+    width: 50%;
+    height: 20px;
+    border-top: 2px solid var(--border);
+    content: '';
+  }
+
+  li::after {
+    right: auto;
+    left: 50%;
+    border-left: 2px solid var(--border);
+  }
+
+  /* We need to remove left-right connectors from elements without any siblings */
+  li:only-child::after, li:only-child::before {
+    display: none;
+  }
+
+  /* Remove space from the top of single children */
+  li:only-child {
+    padding-top: 0;
+  }
+
+  /* Remove left connector from first child and right connector from last child */
+  li:first-child::before, li:last-child::after {
+    border: 0 none;
+  }
+
+  /* Adding back the vertical connector to the last nodes */
+  li:last-child::before {
+    border-right: 2px solid var(--border);
+    border-radius: 0 5px 0 0;
+  }
+
+  li:first-child::after {
+    border-radius: 5px 0 0;
+  }
+
+  /* Time to add downward connectors from parents */
+  ul ul::before {
+    position: absolute;
+    top: 0;
+    left: 50%;
+    width: 0;
+    height: 20px;
+    border-left: 2px solid var(--border);
+    content: '';
+  }
+
+  /* Hide connectors for the absolute root level items */
+  > ul > li::before, > ul > li::after {
+    border: 0 !important;
+  }
+  
+  /* Node styles */
+  .node-card {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 16px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    font-family: var(--font-family);
+    font-size: 14px;
+    color: var(--text-body);
+    text-decoration: none;
+    background: var(--surface-raised);
+    box-shadow: 0 2px 5px rgb(0 0 0 / 5%);
+    cursor: pointer;
+    transition: all 0.2s ease;
+
+    &:hover {
+      border-color: var(--primary);
+      color: var(--primary);
+      background: var(--primary-light, var(--surface-hover));
+      box-shadow: 0 4px 10px rgb(0 0 0 / 10%);
+      transform: translateY(-2px);
+    }
+
+    svg {
+      width: 18px;
+      height: 18px;
+    }
+  }
+
+  .node-label {
+    font-weight: 500;
+    white-space: nowrap;
+  }
+}
+</style>

--- a/frontend/app/components/ViewSelection.vue
+++ b/frontend/app/components/ViewSelection.vue
@@ -9,14 +9,16 @@
 
 <script setup lang="ts">
 import localForage from 'localforage';
-export type ViewMode = 'kanban' | 'list' | 'table' | 'advanced';
+export type ViewMode = 'kanban' | 'list' | 'table' | 'advanced' | 'graph';
 
 const props = withDefaults(
   defineProps<{
     showKanban?: boolean;
+    showGraph?: boolean;
   }>(),
   {
     showKanban: false,
+    showGraph: false,
   },
 );
 
@@ -35,6 +37,9 @@ const viewOptions = computed(() => {
   if (props.showKanban) {
     options.push({ icon: 'kanban', label: t('components.viewSelection.kanban'), value: 'kanban' as ViewMode });
   }
+  if (props.showGraph) {
+    options.push({ icon: 'nodes', label: 'Graph', value: 'graph' as ViewMode });
+  }
   return options;
 });
 
@@ -47,6 +52,7 @@ onMounted(async () => {
   const list = ['table', 'list'];
   if (preferences.get('advancedView').value) list.push('advanced');
   if (props.showKanban) list.push('kanban');
+  if (props.showGraph) list.push('graph');
   if (storedView && list.includes(storedView)) view.value = storedView as ViewMode;
   else view.value = 'table';
 });

--- a/frontend/app/pages/dashboard/categories/index.vue
+++ b/frontend/app/pages/dashboard/categories/index.vue
@@ -10,16 +10,25 @@
       </NuxtLink>
     </Teleport>
 
-    <div style="padding-bottom: 10px">
+    <div style=" display: flex; justify-content: space-between; align-items: center;padding-bottom: 10px;">
       <input v-model="filter" :placeholder="t('nodes.container.searchPlaceholder')" />
+      <ViewSelection v-model="view" :show-graph="true" />
     </div>
-    <div v-for="workspace in filteredItems" :key="workspace.id" class="workspace">
-      <h3 class="wp-name">
-        <NuxtLink :to="`/dashboard/categories/${workspace.id}/edit`">{{ workspace.label }}</NuxtLink>
-      </h3>
-      <WorkspaceTree v-for="node in workspace.children" :key="node.id" :node="node" @edit="editNode" @delete="deleteNode" />
+    
+    <div v-if="view !== 'graph'">
+      <div v-for="workspace in filteredItems" :key="workspace.id" class="workspace">
+        <h3 class="wp-name">
+          <NuxtLink :to="`/dashboard/categories/${workspace.id}/edit`">{{ workspace.label }}</NuxtLink>
+        </h3>
+        <WorkspaceTree v-for="node in workspace.children" :key="node.id" :node="node" @edit="editNode" @delete="deleteNode" />
+      </div>
+      <div v-if="!filteredItems.length" style="font-style: italic; color: #6c757d">{{ t('nodes.container.noWorkspaces') }}</div>
     </div>
-    <div v-if="!filteredItems.length" style=" font-style: italic;color: #6c757d">{{ t('nodes.container.noWorkspaces') }}</div>
+    
+    <div v-else>
+      <GraphView :nodes="graphItems" @node-click="editNode" />
+      <div v-if="!filteredItems.length" style="font-style: italic; color: #6c757d">{{ t('nodes.container.noWorkspaces') }}</div>
+    </div>
   </div>
 </template>
 
@@ -27,6 +36,8 @@
 import CreateCategoryModal from '~/components/Node/Modals/CreateCategory.vue';
 import DeleteCategoryModal from '~/components/Node/Modals/Delete.vue';
 import WorkspaceTree from './_components/WorkspaceTree.vue';
+import ViewSelection, { type ViewMode } from '~/components/ViewSelection.vue';
+import GraphView from '~/components/Node/GraphView.vue';
 import { filterTreeByLabel, type TreeItem } from '~/helpers/TreeBuilder';
 import type { Node } from '~/stores';
 
@@ -37,9 +48,18 @@ const modals = useModal();
 const router = useRouter();
 
 const filter = ref('');
+const view = ref<ViewMode>('list');
 
 const filteredItems = computed(() => {
   const items = nodesTree.getTreeUpToRole(2).value;
+  if (!filter.value.trim()) return items;
+  return filterTreeByLabel(items, filter.value);
+});
+
+// For the graph view, we include documents (role 3) so users can see the full tree structure,
+// especially useful since many workspaces only contain documents and no sub-categories.
+const graphItems = computed(() => {
+  const items = nodesTree.tree.value;
   if (!filter.value.trim()) return items;
   return filterTreeByLabel(items, filter.value);
 });

--- a/frontend/app/pages/dashboard/teams/index.vue
+++ b/frontend/app/pages/dashboard/teams/index.vue
@@ -19,10 +19,17 @@
         <Icon name="search" />
         <input v-model="query" type="text" placeholder="Search teams" />
       </div>
-      <div class="count-pill">{{ filteredTeams.length }} {{ t('teams.teamsCount') }}</div>
+      <div style="display: flex; align-items: center; gap: 10px;">
+        <div class="count-pill">{{ filteredTeams.length }} {{ t('teams.teamsCount') }}</div>
+        <ViewSelection v-model="view" :show-graph="true" />
+      </div>
     </section>
 
-    <section v-if="filteredTeams.length" class="team-grid">
+    <div v-if="view === 'graph'">
+      <GraphView :nodes="graphTeams" @node-click="(node) => router.push(`/dashboard/teams/${node.id}`)" />
+    </div>
+    
+    <section v-else-if="filteredTeams.length" class="team-grid">
       <NodeCardTeam v-for="team in filteredTeams" :key="team.id" :team="team" />
     </section>
 
@@ -34,12 +41,19 @@
 
 <script setup lang="ts">
 import CreateCategoryModal from '~/components/Node/Modals/CreateCategory.vue';
+import ViewSelection, { type ViewMode } from '~/components/ViewSelection.vue';
+import GraphView from '~/components/Node/GraphView.vue';
+import type { TreeItem } from '~/helpers/TreeBuilder';
+import type { Node } from '~/stores';
 
 const nodesStore = useNodesStore();
+
 const modals = useModal();
+const router = useRouter();
 const { t } = useI18nT();
 
 const query = ref('');
+const view = ref<ViewMode>('list');
 
 const teams = computed(() => nodesStore.teams.toSorted((a, b) => a.name.localeCompare(b.name)));
 const filteredTeams = computed(() => {
@@ -49,6 +63,19 @@ const filteredTeams = computed(() => {
 });
 
 const openCreateTeam = () => modals.add(new Modal(shallowRef(CreateCategoryModal), { props: { role: 0, parentId: undefined }, size: 'small' }));
+
+// For graph view, we need TreeItem format
+const graphTeams = computed<TreeItem<Node>[]>(() => {
+  return filteredTeams.value.map(team => {
+    return {
+      id: team.id,
+      label: team.name,
+      data: team,
+      route: `/dashboard/teams/${team.id}`,
+      children: [], // Teams could potentially have children, but keeping it flat for now as requested
+    };
+  });
+});
 </script>
 
 <style scoped lang="scss">


### PR DESCRIPTION

- Implemented a native HTML/CSS recursive `GraphView` component for visualizing nested node structures.
- Updated `ViewSelection` to support a new 'graph' toggle, utilizing the built-in `nodes` network icon.
- Integrated `GraphView` into the Categories dashboard to display full workspace, category, and document hierarchies.
- Integrated `GraphView` into the Teams dashboard for a structural overview.
- Resolved Vue scoped CSS and specificity issues to ensure accurate rendering of connector lines across all branches.
- Fixed linting warnings and TypeScript typing constraints for `TreeItem` models.

Closes #740
